### PR TITLE
Node as a service staking

### DIFF
--- a/contracts/NodeAsAService.sol
+++ b/contracts/NodeAsAService.sol
@@ -58,13 +58,10 @@ contract NodeAsAService is
   error ZeroAddress();
   error InvalidPrice();
   error InsufficientBalance();
-  error TransferFailed();
   error MustPayForAtLeastOneLicense();
   error DurationMustBeGreaterThanZero();
-  error DurationMustBeMultipleOf30Days();
   error AmountMustBeGreaterThanZero();
   error InsufficientContractBalance();
-  error InvalidPaymentRecordIndex();
   error ContractPaused();
   error InvalidTreasuryAddress();
 

--- a/contracts/NodeAsAService.sol
+++ b/contracts/NodeAsAService.sol
@@ -2,420 +2,237 @@
 pragma solidity 0.8.25;
 
 import "@openzeppelin-contracts-5.3.0/token/ERC20/IERC20.sol";
-import "@openzeppelin-contracts-upgradeable-5.3.0/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
-import "@openzeppelin-contracts-upgradeable-5.3.0/utils/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin-contracts-5.3.0/token/ERC20/utils/SafeERC20.sol";
+import
+  "@openzeppelin-contracts-upgradeable-5.3.0/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
+
 import "@openzeppelin-contracts-upgradeable-5.3.0/proxy/utils/Initializable.sol";
 import "@openzeppelin-contracts-upgradeable-5.3.0/proxy/utils/UUPSUpgradeable.sol";
-import "./tokens/NodeLicense.sol";
+import "@openzeppelin-contracts-upgradeable-5.3.0/utils/ReentrancyGuardUpgradeable.sol";
 
 /**
  * @title NodeAsAService
  * @notice Contract for managing node rental payments and service records
  * @dev This contract handles USDC payments for node rentals and manages payment records
  */
-contract NodeAsAService is 
-    Initializable,
-    AccessControlDefaultAdminRulesUpgradeable,
-    ReentrancyGuardUpgradeable,
-    UUPSUpgradeable 
+struct PaymentRecord {
+  uint8 licenseCount; // Number of licenses being paid for
+  uint8 durationInMonths; // 1 Month = 30 days
+  uint256 totalAmountPaidInUSDC; // Total amount paid in USDC
+  uint256 pricePerMonthInUSDC; // Price per 30 days in USDC (6 decimals)
+  address buyer; // The user who purchased the licenses
+  bytes32 subnetId; // The subnet this payment is for
+}
+
+contract NodeAsAService is
+  Initializable,
+  AccessControlDefaultAdminRulesUpgradeable,
+  ReentrancyGuardUpgradeable,
+  UUPSUpgradeable
 {
-    struct TokenAssignment {
-        uint256 tokenId; // the token ids of the license
-        bytes nodeId;  // Empty bytes if no nodeId assigned yet
+  using SafeERC20 for IERC20;
+
+  bytes32 public constant PROTOCOL_MANAGER_ROLE = keccak256("PROTOCOL_MANAGER_ROLE");
+
+  IERC20 public usdc;
+  uint32 public invoiceNumber;
+  uint256 public licensePricePerMonth; // Price in USDC (6 decimals) for a 30-day period
+  bool public isPaused;
+
+  mapping(uint32 invoiceNumber => PaymentRecord) public paymentRecord;
+  mapping(address buyer => uint32[] invoiceNumbers) public buyerInvoices;
+
+  event PaidForNodeServices(
+    uint32 indexed invoiceNumber,
+    address indexed buyer,
+    bytes32 indexed subnetId,
+    uint8 licenseCount,
+    uint8 durationInMonths,
+    uint256 totalAmountPaidInUSDC,
+    uint256 priceAtPayment
+  );
+  event LicensePriceUpdated(uint256 oldPrice, uint256 newPrice);
+  event PauseStateChanged(bool isPaused);
+
+  error ZeroAddress();
+  error InvalidPrice();
+  error InsufficientBalance();
+  error TransferFailed();
+  error MustPayForAtLeastOneLicense();
+  error DurationMustBeGreaterThanZero();
+  error DurationMustBeMultipleOf30Days();
+  error AmountMustBeGreaterThanZero();
+  error InsufficientContractBalance();
+  error InvalidPaymentRecordIndex();
+  error ContractPaused();
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  /**
+   * @notice Initializes the contract with required parameters
+   * @param _usdc Address of the USDC token contract
+   * @param _defaultAdmin Address that will have admin privileges
+   * @param _initialPricePerMonthInUSDC Initial price for a 30-day period in USDC (6 decimals)
+   */
+  function initialize(
+    address _usdc,
+    address _defaultAdmin,
+    uint256 _initialPricePerMonthInUSDC
+  ) public initializer {
+    if (_usdc == address(0)) {
+      revert ZeroAddress();
+    }
+    if (_initialPricePerMonthInUSDC == 0) {
+      revert InvalidPrice();
     }
 
-    struct PaymentRecord {
-        address user;  // The user who owns this payment record
-        uint256 licenseCount;  // Number of licenses being paid for
-        bytes32 subnetId;  // The subnet this payment is for
-        uint256 totalCumulativeDurationInSeconds;  // Total duration in seconds for all licenses combined
-        uint256 totalAmountPaidInUSDC;  // Total amount paid in USDC
-        uint256 startTime;  // When the payment started
-        uint256 priceAtPayment; // Price per 30 days in USDC (6 decimals)
-        TokenAssignment[100] tokenAssignments;  // Fixed size array for token assignments (max 100 licenses)
+    __AccessControlDefaultAdminRules_init(0, _defaultAdmin);
+    __ReentrancyGuard_init();
+    __UUPSUpgradeable_init();
+
+    usdc = IERC20(_usdc);
+    licensePricePerMonth = _initialPricePerMonthInUSDC;
+    invoiceNumber = 1; // Initialize, e.g., to start invoices from 1
+    isPaused = false;
+  }
+
+  ///
+  /// EXTERNAL FUNCTIONS - PAYMENT AND TOKEN MANAGEMENT
+  ///
+
+  /**
+   * @notice Pays for node services per node license
+   * @param licenseCount Number of licenses to pay for
+   * @param durationInMonths Total duration in months for each license
+   * @param subnetId The ID of the subnet being paid for
+   * @dev Requires USDC approval for the payment amount.
+   */
+  function payForNodeServices(uint8 licenseCount, uint8 durationInMonths, bytes32 subnetId)
+    external
+    nonReentrant
+  {
+    if (isPaused) {
+      revert ContractPaused();
     }
-    
-    bytes32 public constant SCRIBE_ROLE = keccak256("SCRIBE_ROLE");
-    bytes32 public constant PROTOCOL_MANAGER_ROLE = keccak256("PROTOCOL_MANAGER_ROLE");
-    
-    IERC20 public usdc;
-    NodeLicense public nodeLicense;
-    
-    uint256 public licensePricePer30Days; // Price in USDC (6 decimals) for a 30-day period
-    
-    mapping(address => PaymentRecord[]) public userPaymentRecords;
-    
-    event PaidForNodeServices(
-        address indexed user,
-        uint256 licenseCount,
-        bytes32 subnetId,
-        uint256 totalCumulativeDurationInSeconds,
-        uint256 totalAmountPaidInUSDC,
-        uint256 startTime,
-        uint256 priceAtPayment // Price per 30 days in USDC (6 decimals)
-    );
-    event LicensePriceUpdated(uint256 oldPrice, uint256 newPrice);
-    event TokenAssignmentUpdated(
-        address indexed user,
-        uint256 indexed paymentRecordIndex,
-        uint256[] tokenIds,
-        bytes[] nodeIds
-    );
-    
-    error ZeroAddress();
-    error InvalidPrice();
-    error InsufficientBalance();
-    error TransferFailed();
-    error MustPayForAtLeastOneLicense();
-    error DurationMustBeGreaterThanZero();
-    error DurationMustBeMultipleOf30Days();
-    error AmountMustBeGreaterThanZero();
-    error InsufficientContractBalance();
-    error InvalidPaymentRecordIndex();
-    error EmptyTokenIds();
-    error TokenIdNotFound();
-    error TokenIdNodeIdMismatch();
-    error TooManyLicenses();
-    
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
-        _disableInitializers();
+    if (licenseCount == 0) {
+      revert MustPayForAtLeastOneLicense();
     }
-    
-    /**
-     * @notice Initializes the contract with required parameters
-     * @param _usdc Address of the USDC token contract
-     * @param _nodeLicense Address of the NodeLicense contract
-     * @param _defaultAdmin Address that will have admin privileges
-     * @param _scribe Address that will have scribe privileges
-     * @param _initialPricePer30Days Initial price for a 30-day period in USDC (6 decimals)
-     */
-    function initialize(
-        address _usdc,
-        address _nodeLicense,
-        address _defaultAdmin,
-        address _scribe,
-        uint256 _initialPricePer30Days
-    ) public initializer {
-        if (_usdc == address(0) || _nodeLicense == address(0))
-        {
-            revert ZeroAddress();
-        }
-        if (_initialPricePer30Days == 0)
-        {
-            revert InvalidPrice();
-        }
-        
-        __AccessControlDefaultAdminRules_init(0, _defaultAdmin);
-        __ReentrancyGuard_init();
-        __UUPSUpgradeable_init();
-        
-        _grantRole(SCRIBE_ROLE, _scribe);
-        
-        usdc = IERC20(_usdc);
-        nodeLicense = NodeLicense(_nodeLicense);
-        licensePricePer30Days = _initialPricePer30Days;
+    if (durationInMonths == 0) {
+      revert DurationMustBeGreaterThanZero();
     }
 
-    ///
-    /// EXTERNAL FUNCTIONS - PAYMENT AND TOKEN MANAGEMENT
-    ///
-    
-    /**
-     * @notice Pays for node services per node license
-     * @param licenseCount Number of licenses to pay for
-     * @param totalCumulativeDurationInSeconds Total duration in seconds for all licenses combined (e.g., for 2 licenses of 30 days each, this would be 60 days in seconds)
-     * @param subnetId The ID of the subnet being paid for
-     * @dev Requires USDC approval for the payment amount. The total duration should be the sum of durations for all licenses and must be a multiple of 30 days.
-     */
-    function payForNodeServices(
-        uint256 licenseCount, 
-        uint256 totalCumulativeDurationInSeconds, 
-        bytes32 subnetId
-    ) external nonReentrant {
-        if (licenseCount == 0)
-        {
-            revert MustPayForAtLeastOneLicense();
-        }
-        if (licenseCount > 100)
-        {
-            revert TooManyLicenses();
-        }
-        if (totalCumulativeDurationInSeconds == 0)
-        {
-            revert DurationMustBeGreaterThanZero();
-        }
-        
-        // Check if duration is a multiple of 30 days
-        if (totalCumulativeDurationInSeconds % (30 days) != 0)
-        {
-            revert DurationMustBeMultipleOf30Days();
-        }
-        
-        // Calculate required payment
-        uint256 requiredPayment = calculateRequiredPayment(totalCumulativeDurationInSeconds);
-        if (usdc.balanceOf(msg.sender) < requiredPayment)
-        {
-            revert InsufficientBalance();
-        }
-        if (!usdc.transferFrom(msg.sender, address(this), requiredPayment))
-        {
-            revert TransferFailed();
-        }
-        
-        uint256 startTime = block.timestamp;
-        
-        // Initialize payment record directly in storage
-        PaymentRecord storage newPayment = userPaymentRecords[msg.sender].push();
-        newPayment.user = msg.sender;
-        newPayment.licenseCount = licenseCount;
-        newPayment.subnetId = subnetId;
-        newPayment.totalCumulativeDurationInSeconds = totalCumulativeDurationInSeconds;
-        newPayment.totalAmountPaidInUSDC = requiredPayment;
-        newPayment.startTime = startTime;
-        newPayment.priceAtPayment = licensePricePer30Days;
-        
-        // Initialize empty token assignments
-        for (uint256 i = 0; i < 100; i++) {
-            newPayment.tokenAssignments[i].tokenId = 0;
-            newPayment.tokenAssignments[i].nodeId = bytes("");
-        }
-        
-        emit PaidForNodeServices({
-            user: msg.sender,
-            licenseCount: licenseCount,
-            subnetId: subnetId,
-            totalCumulativeDurationInSeconds: totalCumulativeDurationInSeconds,
-            totalAmountPaidInUSDC: requiredPayment,
-            startTime: startTime,
-            priceAtPayment: licensePricePer30Days
-        });
+    // Calculate required payment
+    uint256 requiredPayment = licensePricePerMonth * licenseCount * durationInMonths;
+    if (usdc.balanceOf(msg.sender) < requiredPayment) {
+      revert InsufficientBalance();
     }
+    usdc.safeTransferFrom(msg.sender, address(this), requiredPayment);
 
-    /**
-     * @notice Adds tokenIDs and their corresponding nodeIDs to a specific payment record
-     * @param user Address of the user whose payment record to update
-     * @param paymentRecordIndex Index of the payment record to update
-     * @param tokenIds Array of token IDs to add
-     * @param nodeIds Array of nodeIDs corresponding to each tokenID (should be empty bytes if no nodeID is assigned yet)
-     * @dev Only callable by scribes. Each tokenID must have a corresponding nodeID at the same index.
-     */
-    function addTokenAssignments(
-        address user,
-        uint256 paymentRecordIndex,
-        uint256[] calldata tokenIds,
-        bytes[] calldata nodeIds
-    ) external onlyRole(SCRIBE_ROLE) {
-        if (tokenIds.length == 0)
-        {
-            revert EmptyTokenIds();
-        }
-        if (tokenIds.length != nodeIds.length)
-        {
-            revert TokenIdNodeIdMismatch();
-        }
-        if (paymentRecordIndex >= userPaymentRecords[user].length)
-        {
-            revert InvalidPaymentRecordIndex();
-        }
+    paymentRecord[invoiceNumber].buyer = msg.sender;
+    paymentRecord[invoiceNumber].licenseCount = licenseCount;
+    paymentRecord[invoiceNumber].subnetId = subnetId;
+    paymentRecord[invoiceNumber].durationInMonths = durationInMonths;
+    paymentRecord[invoiceNumber].totalAmountPaidInUSDC = requiredPayment;
+    paymentRecord[invoiceNumber].pricePerMonthInUSDC = licensePricePerMonth;
 
-        PaymentRecord storage record = userPaymentRecords[user][paymentRecordIndex];
-        
-        // Add each tokenId and its nodeId
-        for (uint256 i = 0; i < tokenIds.length; i++)
-        {
-            record.tokenAssignments[i] = TokenAssignment({
-                tokenId: tokenIds[i],
-                nodeId: nodeIds[i]
-            });
-        }
+    buyerInvoices[msg.sender].push(invoiceNumber);
 
-        emit TokenAssignmentUpdated({
-            user: user,
-            paymentRecordIndex: paymentRecordIndex,
-            tokenIds: tokenIds,
-            nodeIds: nodeIds
-        });
+    invoiceNumber++;
+
+    emit PaidForNodeServices({
+      invoiceNumber: invoiceNumber,
+      buyer: msg.sender,
+      licenseCount: licenseCount,
+      subnetId: subnetId,
+      durationInMonths: durationInMonths,
+      totalAmountPaidInUSDC: requiredPayment,
+      priceAtPayment: licensePricePerMonth
+    });
+  }
+
+  /**
+   * @notice Withdraws USDC from the contract
+   * @param amount Amount of USDC to withdraw
+   * @dev Only callable by protocol managers
+   */
+  function withdrawFunds(uint256 amount) external onlyRole(PROTOCOL_MANAGER_ROLE) nonReentrant {
+    if (amount == 0) {
+      revert AmountMustBeGreaterThanZero();
     }
-
-    /**
-     * @notice Updates the nodeID for a specific tokenID in a payment record
-     * @param user Address of the user whose payment record to update
-     * @param paymentRecordIndex Index of the payment record to update
-     * @param tokenId The token ID to update
-     * @param nodeId The new nodeID to assign
-     * @dev Only callable by scribes. Will revert if tokenId is not found.
-     */
-    function updateNodeId(
-        address user,
-        uint256 paymentRecordIndex,
-        uint256 tokenId,
-        bytes calldata nodeId
-    ) external onlyRole(SCRIBE_ROLE) {
-        if (paymentRecordIndex >= userPaymentRecords[user].length)
-        {
-            revert InvalidPaymentRecordIndex();
-        }
-
-        PaymentRecord storage record = userPaymentRecords[user][paymentRecordIndex];
-        
-        // Find the token assignment
-        for (uint256 i = 0; i < record.licenseCount; i++) {
-            if (record.tokenAssignments[i].tokenId == tokenId) {
-                record.tokenAssignments[i].nodeId = nodeId;
-                emit TokenAssignmentUpdated({
-                    user: user,
-                    paymentRecordIndex: paymentRecordIndex,
-                    tokenIds: new uint256[](1),
-                    nodeIds: new bytes[](1)
-                });
-                return;
-            }
-        }
-        
-        revert TokenIdNotFound();
+    if (usdc.balanceOf(address(this)) < amount) {
+      revert InsufficientContractBalance();
     }
+    usdc.safeTransfer(msg.sender, amount);
+  }
 
-    /**
-     * @notice Withdraws USDC from the contract
-     * @param amount Amount of USDC to withdraw
-     * @dev Only callable by protocol managers
-     */
-    function withdrawFunds(uint256 amount) external onlyRole(PROTOCOL_MANAGER_ROLE) nonReentrant {
-        if (amount == 0)
-        {
-            revert AmountMustBeGreaterThanZero();
-        }
-        if (usdc.balanceOf(address(this)) < amount)
-        {
-            revert InsufficientContractBalance();
-        }
-        if (!usdc.transfer(msg.sender, amount))
-        {
-            revert TransferFailed();
-        }
+  ///
+  /// EXTERNAL FUNCTIONS - ADMIN AND CONFIGURATION
+  ///
+
+  /**
+   * @notice Sets the price per 30 days for licenses
+   * @param _newPricePerMonth New price per 30 days in USDC (6 decimals)
+   * @dev Only callable by the default admin
+   */
+  function setLicensePricePerMonth(uint256 _newPricePerMonth) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    if (_newPricePerMonth == 0) {
+      revert InvalidPrice();
     }
+    emit LicensePriceUpdated(licensePricePerMonth, _newPricePerMonth);
+    licensePricePerMonth = _newPricePerMonth;
+  }
 
-    ///
-    /// EXTERNAL FUNCTIONS - ADMIN AND CONFIGURATION
-    ///
+  function setPaused(bool _isPaused) external onlyRole(PROTOCOL_MANAGER_ROLE) {
+    isPaused = _isPaused;
+    emit PauseStateChanged(_isPaused);
+  }
 
-    /**
-     * @notice Sets the price per 30 days for licenses
-     * @param _newPricePer30Days New price per 30 days in USDC (6 decimals)
-     * @dev Only callable by the default admin
-     */
-    function setLicensePricePer30Days(uint256 _newPricePer30Days) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (_newPricePer30Days == 0)
-        {
-            revert InvalidPrice();
-        }
-        emit LicensePriceUpdated(licensePricePer30Days, _newPricePer30Days);
-        licensePricePer30Days = _newPricePer30Days;
-    }
+  ///
+  /// PUBLIC VIEW FUNCTIONS
+  ///
 
-    /**
-     * @notice Grants the SCRIBE_ROLE to an address
-     * @param scribe Address to grant scribe role to
-     * @dev Only callable by the default admin
-     */
-    function setContractScribe(address scribe) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (scribe == address(0))
-        {
-            revert ZeroAddress();
-        }
-        _grantRole(SCRIBE_ROLE, scribe);
-    }
+  /**
+   * @notice Gets all payment records for a user
+   * @param _buyer Address of the purchaser
+   * @return Array of invoice numbers
+   */
+  function getInvoiceNumbers(address _buyer) external view returns (uint32[] memory) {
+    return buyerInvoices[_buyer];
+  }
 
-    /**
-     * @notice Grants the PROTOCOL_MANAGER_ROLE to an address
-     * @param manager Address to grant protocol manager role to
-     * @dev Only callable by the default admin
-     */
-    function setProtocolManager(address manager) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (manager == address(0))
-        {
-            revert ZeroAddress();
-        }
-        _grantRole(PROTOCOL_MANAGER_ROLE, manager);
-    }
+  function getPaymentRecord(uint32 _invoiceNumber) external view returns (PaymentRecord memory) {
+    return paymentRecord[_invoiceNumber];
+  }
 
-    ///
-    /// PUBLIC VIEW FUNCTIONS
-    ///
+  /**
+   * @notice Checks if contract supports an interface
+   * @param interfaceId Interface ID to check
+   * @return True if the interface is supported
+   */
+  function supportsInterface(bytes4 interfaceId)
+    public
+    view
+    override (AccessControlDefaultAdminRulesUpgradeable)
+    returns (bool)
+  {
+    return super.supportsInterface(interfaceId);
+  }
 
-    /**
-     * @notice Gets all payment records for a user
-     * @param user Address of the user
-     * @return Array of payment records
-     */
-    function getUserPaymentRecords(address user) external view returns (PaymentRecord[] memory) {
-        return userPaymentRecords[user];
-    }
+  ///
+  /// INTERNAL FUNCTIONS
+  ///
 
-    /**
-     * @notice Gets the nodeID for a specific tokenID in a payment record
-     * @param user Address of the user whose payment record to check
-     * @param paymentRecordIndex Index of the payment record to check
-     * @param tokenId The token ID to check
-     * @return The nodeID assigned to the tokenID
-     */
-    function getNodeIdForToken(
-        address user,
-        uint256 paymentRecordIndex,
-        uint256 tokenId
-    ) external view returns (bytes memory) {
-        if (paymentRecordIndex >= userPaymentRecords[user].length)
-        {
-            revert InvalidPaymentRecordIndex();
-        }
-
-        PaymentRecord storage record = userPaymentRecords[user][paymentRecordIndex];
-        
-        for (uint256 i = 0; i < record.licenseCount; i++) {
-            if (record.tokenAssignments[i].tokenId == tokenId) {
-                return record.tokenAssignments[i].nodeId;
-            }
-        }
-        
-        return bytes("");
-    }
-
-    /**
-     * @notice Calculates the required USDC payment for node services
-     * @param totalCumulativeDurationInSeconds Total duration in seconds for all licenses combined
-     * @return Required payment amount in USDC
-     * @dev The total duration must be a multiple of 30 days. For example, for 2 licenses of 30 days each,
-     *      totalCumulativeDurationInSeconds should be 60 days in seconds.
-     */
-    function calculateRequiredPayment(uint256 totalCumulativeDurationInSeconds) public view returns (uint256) {
-        uint256 thirtyDaysInSeconds = 30 days;
-        uint256 num30DayPeriods = totalCumulativeDurationInSeconds / thirtyDaysInSeconds;
-        return licensePricePer30Days * num30DayPeriods;
-    }
-
-    /**
-     * @notice Checks if contract supports an interface
-     * @param interfaceId Interface ID to check
-     * @return True if the interface is supported
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        override(AccessControlDefaultAdminRulesUpgradeable)
-        returns (bool)
-    {
-        return super.supportsInterface(interfaceId);
-    }
-
-    ///
-    /// INTERNAL FUNCTIONS
-    ///
-
-    /**
-     * @notice Authorizes contract upgrade
-     * @param newImplementation Address of the new implementation
-     * @dev Only callable by the default admin
-     */
-    function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+  /**
+   * @notice Authorizes contract upgrade
+   * @param newImplementation Address of the new implementation
+   * @dev Only callable by the default admin
+   */
+  function _authorizeUpgrade(address newImplementation)
+    internal
+    override
+    onlyRole(DEFAULT_ADMIN_ROLE)
+  { }
 }

--- a/contracts/NodeAsAService.sol
+++ b/contracts/NodeAsAService.sol
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "@openzeppelin-contracts-5.3.0/token/ERC20/IERC20.sol";
+import "@openzeppelin-contracts-upgradeable-5.3.0/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
+import "@openzeppelin-contracts-upgradeable-5.3.0/utils/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin-contracts-upgradeable-5.3.0/proxy/utils/Initializable.sol";
+import "@openzeppelin-contracts-upgradeable-5.3.0/proxy/utils/UUPSUpgradeable.sol";
+import "./tokens/NodeLicense.sol";
+
+/**
+ * @title NodeAsAService
+ * @notice Contract for managing node rental payments and service records
+ * @dev This contract handles USDC payments for node rentals and manages payment records
+ */
+contract NodeAsAService is 
+    Initializable,
+    AccessControlDefaultAdminRulesUpgradeable,
+    ReentrancyGuardUpgradeable,
+    UUPSUpgradeable 
+{
+    struct TokenAssignment {
+        uint256 tokenId; // the token ids of the license
+        bytes nodeId;  // Empty bytes if no nodeId assigned yet
+    }
+
+    struct PaymentRecord {
+        address user;  // The user who owns this payment record
+        uint256 licenseCount;  // Number of licenses being paid for
+        bytes32 subnetId;  // The subnet this payment is for
+        uint256 totalCumulativeDurationInSeconds;  // Duration in seconds
+        uint256 totalAmountPaidInUSDC;  // Total amount paid in USDC
+        uint256 startTime;  // When the payment started
+        uint256 pricePerMonthAtPayment; // Price in USDC (6 decimals)
+        TokenAssignment[100] tokenAssignments;  // Fixed size array for token assignments (max 100 licenses)
+    }
+    
+    bytes32 public constant SCRIBE_ROLE = keccak256("SCRIBE_ROLE");
+    bytes32 public constant PROTOCOL_MANAGER_ROLE = keccak256("PROTOCOL_MANAGER_ROLE");
+    
+    IERC20 public usdc;
+    NodeLicense public nodeLicense;
+    
+    uint256 public licensePricePerMonth; // Price in USDC (6 decimals)
+    
+    mapping(address => PaymentRecord[]) public userPaymentRecords;
+    
+    event PaidForNodeServices(
+        address indexed user,
+        uint256 licenseCount,
+        bytes32 subnetId,
+        uint256 totalCumulativeDurationInSeconds,
+        uint256 totalAmountPaidInUSDC,
+        uint256 startTime,
+        uint256 pricePerMonthAtPayment
+    );
+    event LicensePriceUpdated(uint256 oldPrice, uint256 newPrice);
+    event TokenAssignmentUpdated(
+        address indexed user,
+        uint256 indexed paymentRecordIndex,
+        uint256[] tokenIds,
+        bytes[] nodeIds
+    );
+    
+    error ZeroAddress();
+    error InvalidPrice();
+    error InsufficientBalance();
+    error TransferFailed();
+    error MustPayForAtLeastOneLicense();
+    error DurationMustBeGreaterThanZero();
+    error AmountMustBeGreaterThanZero();
+    error InsufficientContractBalance();
+    error InvalidPaymentRecordIndex();
+    error EmptyTokenIds();
+    error TokenIdNotFound();
+    error TokenIdNodeIdMismatch();
+    error TooManyLicenses();
+    
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+    
+    /**
+     * @notice Initializes the contract with required parameters
+     * @param _usdc Address of the USDC token contract
+     * @param _nodeLicense Address of the NodeLicense contract
+     * @param _defaultAdmin Address that will have admin privileges
+     * @param _scribe Address that will have scribe privileges
+     * @param _initialPricePerMonth Initial price per month in USDC (6 decimals)
+     */
+    function initialize(
+        address _usdc,
+        address _nodeLicense,
+        address _defaultAdmin,
+        address _scribe,
+        uint256 _initialPricePerMonth
+    ) public initializer {
+        if (_usdc == address(0) || _nodeLicense == address(0))
+        {
+            revert ZeroAddress();
+        }
+        if (_initialPricePerMonth == 0)
+        {
+            revert InvalidPrice();
+        }
+        
+        __AccessControlDefaultAdminRules_init(0, _defaultAdmin);
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+        
+        _grantRole(SCRIBE_ROLE, _scribe);
+        
+        usdc = IERC20(_usdc);
+        nodeLicense = NodeLicense(_nodeLicense);
+        licensePricePerMonth = _initialPricePerMonth;
+    }
+
+    ///
+    /// EXTERNAL FUNCTIONS - PAYMENT AND TOKEN MANAGEMENT
+    ///
+    
+    /**
+     * @notice Pays for node services per node license
+     * @param licenseCount Number of licenses to pay for
+     * @param totalCumulativeDurationInSeconds Total duration in seconds for all licenses
+     * @param subnetId The ID of the subnet being paid for
+     * @dev Requires USDC approval for the payment amount
+     */
+    function payForNodeServices(
+        uint256 licenseCount, 
+        uint256 totalCumulativeDurationInSeconds, 
+        bytes32 subnetId
+    ) external nonReentrant {
+        if (licenseCount == 0)
+        {
+            revert MustPayForAtLeastOneLicense();
+        }
+        if (licenseCount > 100)
+        {
+            revert TooManyLicenses();
+        }
+        if (totalCumulativeDurationInSeconds == 0)
+        {
+            revert DurationMustBeGreaterThanZero();
+        }
+        
+        // Calculate required payment
+        uint256 requiredPayment = calculateRequiredPayment(licenseCount, totalCumulativeDurationInSeconds);
+        if (usdc.balanceOf(msg.sender) < requiredPayment)
+        {
+            revert InsufficientBalance();
+        }
+        if (!usdc.transferFrom(msg.sender, address(this), requiredPayment))
+        {
+            revert TransferFailed();
+        }
+        
+        uint256 startTime = block.timestamp;
+        
+        // Initialize payment record directly in storage
+        PaymentRecord storage newPayment = userPaymentRecords[msg.sender].push();
+        newPayment.user = msg.sender;
+        newPayment.licenseCount = licenseCount;
+        newPayment.subnetId = subnetId;
+        newPayment.totalCumulativeDurationInSeconds = totalCumulativeDurationInSeconds;
+        newPayment.totalAmountPaidInUSDC = requiredPayment;
+        newPayment.startTime = startTime;
+        newPayment.pricePerMonthAtPayment = licensePricePerMonth;
+        
+        // Initialize empty token assignments
+        for (uint256 i = 0; i < 100; i++) {
+            newPayment.tokenAssignments[i].tokenId = 0;
+            newPayment.tokenAssignments[i].nodeId = bytes("");
+        }
+        
+        emit PaidForNodeServices({
+            user: msg.sender,
+            licenseCount: licenseCount,
+            subnetId: subnetId,
+            totalCumulativeDurationInSeconds: totalCumulativeDurationInSeconds,
+            totalAmountPaidInUSDC: requiredPayment,
+            startTime: startTime,
+            pricePerMonthAtPayment: licensePricePerMonth
+        });
+    }
+
+    /**
+     * @notice Adds tokenIDs and their corresponding nodeIDs to a specific payment record
+     * @param user Address of the user whose payment record to update
+     * @param paymentRecordIndex Index of the payment record to update
+     * @param tokenIds Array of token IDs to add
+     * @param nodeIds Array of nodeIDs corresponding to each tokenID (should be empty bytes if no nodeID is assigned yet)
+     * @dev Only callable by scribes. Each tokenID must have a corresponding nodeID at the same index.
+     */
+    function addTokenAssignments(
+        address user,
+        uint256 paymentRecordIndex,
+        uint256[] calldata tokenIds,
+        bytes[] calldata nodeIds
+    ) external onlyRole(SCRIBE_ROLE) {
+        if (tokenIds.length == 0)
+        {
+            revert EmptyTokenIds();
+        }
+        if (tokenIds.length != nodeIds.length)
+        {
+            revert TokenIdNodeIdMismatch();
+        }
+        if (paymentRecordIndex >= userPaymentRecords[user].length)
+        {
+            revert InvalidPaymentRecordIndex();
+        }
+
+        PaymentRecord storage record = userPaymentRecords[user][paymentRecordIndex];
+        
+        // Add each tokenId and its nodeId
+        for (uint256 i = 0; i < tokenIds.length; i++)
+        {
+            record.tokenAssignments[i] = TokenAssignment({
+                tokenId: tokenIds[i],
+                nodeId: nodeIds[i]
+            });
+        }
+
+        emit TokenAssignmentUpdated({
+            user: user,
+            paymentRecordIndex: paymentRecordIndex,
+            tokenIds: tokenIds,
+            nodeIds: nodeIds
+        });
+    }
+
+    /**
+     * @notice Updates the nodeID for a specific tokenID in a payment record
+     * @param user Address of the user whose payment record to update
+     * @param paymentRecordIndex Index of the payment record to update
+     * @param tokenId The token ID to update
+     * @param nodeId The new nodeID to assign
+     * @dev Only callable by scribes. Will revert if tokenId is not found.
+     */
+    function updateNodeId(
+        address user,
+        uint256 paymentRecordIndex,
+        uint256 tokenId,
+        bytes calldata nodeId
+    ) external onlyRole(SCRIBE_ROLE) {
+        if (paymentRecordIndex >= userPaymentRecords[user].length)
+        {
+            revert InvalidPaymentRecordIndex();
+        }
+
+        PaymentRecord storage record = userPaymentRecords[user][paymentRecordIndex];
+        
+        // Find the token assignment
+        for (uint256 i = 0; i < record.licenseCount; i++) {
+            if (record.tokenAssignments[i].tokenId == tokenId) {
+                record.tokenAssignments[i].nodeId = nodeId;
+                emit TokenAssignmentUpdated({
+                    user: user,
+                    paymentRecordIndex: paymentRecordIndex,
+                    tokenIds: new uint256[](1),
+                    nodeIds: new bytes[](1)
+                });
+                return;
+            }
+        }
+        
+        revert TokenIdNotFound();
+    }
+
+    /**
+     * @notice Withdraws USDC from the contract
+     * @param amount Amount of USDC to withdraw
+     * @dev Only callable by protocol managers
+     */
+    function withdrawFunds(uint256 amount) external onlyRole(PROTOCOL_MANAGER_ROLE) nonReentrant {
+        if (amount == 0)
+        {
+            revert AmountMustBeGreaterThanZero();
+        }
+        if (usdc.balanceOf(address(this)) < amount)
+        {
+            revert InsufficientContractBalance();
+        }
+        if (!usdc.transfer(msg.sender, amount))
+        {
+            revert TransferFailed();
+        }
+    }
+
+    ///
+    /// EXTERNAL FUNCTIONS - ADMIN AND CONFIGURATION
+    ///
+
+    /**
+     * @notice Sets the price per month for licenses
+     * @param _newPricePerMonth New price per month in USDC (6 decimals)
+     * @dev Only callable by the default admin
+     */
+    function setLicensePricePerMonth(uint256 _newPricePerMonth) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (_newPricePerMonth == 0)
+        {
+            revert InvalidPrice();
+        }
+        emit LicensePriceUpdated(licensePricePerMonth, _newPricePerMonth);
+        licensePricePerMonth = _newPricePerMonth;
+    }
+
+    /**
+     * @notice Grants the SCRIBE_ROLE to an address
+     * @param scribe Address to grant scribe role to
+     * @dev Only callable by the default admin
+     */
+    function setContractScribe(address scribe) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (scribe == address(0))
+        {
+            revert ZeroAddress();
+        }
+        _grantRole(SCRIBE_ROLE, scribe);
+    }
+
+    /**
+     * @notice Grants the PROTOCOL_MANAGER_ROLE to an address
+     * @param manager Address to grant protocol manager role to
+     * @dev Only callable by the default admin
+     */
+    function setProtocolManager(address manager) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (manager == address(0))
+        {
+            revert ZeroAddress();
+        }
+        _grantRole(PROTOCOL_MANAGER_ROLE, manager);
+    }
+
+    ///
+    /// PUBLIC VIEW FUNCTIONS
+    ///
+
+    /**
+     * @notice Gets all payment records for a user
+     * @param user Address of the user
+     * @return Array of payment records
+     */
+    function getUserPaymentRecords(address user) external view returns (PaymentRecord[] memory) {
+        return userPaymentRecords[user];
+    }
+
+    /**
+     * @notice Gets the nodeID for a specific tokenID in a payment record
+     * @param user Address of the user whose payment record to check
+     * @param paymentRecordIndex Index of the payment record to check
+     * @param tokenId The token ID to check
+     * @return The nodeID assigned to the tokenID
+     */
+    function getNodeIdForToken(
+        address user,
+        uint256 paymentRecordIndex,
+        uint256 tokenId
+    ) external view returns (bytes memory) {
+        if (paymentRecordIndex >= userPaymentRecords[user].length)
+        {
+            revert InvalidPaymentRecordIndex();
+        }
+
+        PaymentRecord storage record = userPaymentRecords[user][paymentRecordIndex];
+        
+        for (uint256 i = 0; i < record.licenseCount; i++) {
+            if (record.tokenAssignments[i].tokenId == tokenId) {
+                return record.tokenAssignments[i].nodeId;
+            }
+        }
+        
+        return bytes("");
+    }
+
+    /**
+     * @notice Calculates the required USDC payment for node services
+     * @param licenseCount Number of licenses to pay for
+     * @param totalCumulativeDurationInSeconds Duration in seconds
+     * @return Required payment amount in USDC
+     */
+    function calculateRequiredPayment(uint256 licenseCount, uint256 totalCumulativeDurationInSeconds) public view returns (uint256) {
+        // Convert duration to months (rounding up to nearest month)
+        uint256 secondsInMonth = 30 days;
+        uint256 durationInMonths = (totalCumulativeDurationInSeconds + secondsInMonth - 1) / secondsInMonth;
+        return licensePricePerMonth * durationInMonths * licenseCount;
+    }
+
+    /**
+     * @notice Checks if contract supports an interface
+     * @param interfaceId Interface ID to check
+     * @return True if the interface is supported
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(AccessControlDefaultAdminRulesUpgradeable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    ///
+    /// INTERNAL FUNCTIONS
+    ///
+
+    /**
+     * @notice Authorizes contract upgrade
+     * @param newImplementation Address of the new implementation
+     * @dev Only callable by the default admin
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/script/deployNodeAsAService.s.sol
+++ b/script/deployNodeAsAService.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+import { ERC1967Proxy } from "@openzeppelin-contracts-5.3.0/proxy/ERC1967/ERC1967Proxy.sol";
+import { Script } from "forge-std-1.9.6/src/Script.sol";
+import { console } from "forge-std-1.9.6/src/console.sol";
+
+import { NodeAsAService } from "../contracts/NodeAsAService.sol";
+
+contract DeployNodeAsAService is Script {
+  address public usdc = 0x5425890298aed601595a70AB815c96711a31Bc65; // Fuji USDC address
+  address public admin = vm.envAddress("ETH_FROM");
+  address public protocolManager = vm.envAddress("ETH_FROM");
+  address public treasury = vm.envAddress("ETH_FROM");
+  uint256 public initialPricePerMonth = 0.02 * 1e6; // 2 cents USDC per month
+
+  function run() external {
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    vm.startBroadcast(deployerPrivateKey);
+
+    NodeAsAService impl = new NodeAsAService();
+    console.log("NodeAsAService implementation deployed at:", address(impl));
+
+    bytes memory initData = abi.encodeWithSelector(
+      NodeAsAService.initialize.selector,
+      usdc,
+      admin,
+      initialPricePerMonth,
+      treasury
+    );
+
+    ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+    console.log("NodeAsAService UUPS proxy deployed at:", address(proxy));
+
+    console.log("\nVerification commands:");
+    console.log("forge verify-contract", address(impl), "contracts/NodeAsAService.sol:NodeAsAService --verifier-url 'https://api.routescan.io/v2/network/testnet/evm/43113/etherscan' --etherscan-api-key 'verifyContract' --num-of-optimizations 200 --compiler-version v0.8.25");
+    console.log("forge verify-contract", address(proxy), "dependencies/@openzeppelin-contracts-5.3.0/proxy/ERC1967/ERC1967Proxy.sol:ERC1967Proxy --verifier-url 'https://api.routescan.io/v2/network/testnet/evm/43113/etherscan' --etherscan-api-key 'verifyContract' --num-of-optimizations 200 --compiler-version v0.8.25 --constructor-args $(cast abi-encode \"constructor(address,bytes)\"", address(impl), initData, ")");
+
+    vm.stopBroadcast();
+  }
+} 

--- a/tests/NodeAsAService.t.sol
+++ b/tests/NodeAsAService.t.sol
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+/**
+ * @title NodeAsAServiceTest
+ * @notice Test suite for the NodeAsAService contract
+ * @dev Tests the functionality of node service payments, token assignments, and administrative functions
+ */
+import { NodeAsAService } from "../contracts/NodeAsAService.sol";
+import { ERC721Mock } from "./mocks/ERC721Mock.sol";
+import { MockERC20 } from "./mocks/MockERC20.sol";
+import { ERC1967Proxy } from "../dependencies/@openzeppelin-contracts-5.3.0/proxy/ERC1967/ERC1967Proxy.sol";
+import { Base } from "./utils/Base.sol";
+import { IAccessControl } from "../dependencies/@openzeppelin-contracts-5.3.0/access/IAccessControl.sol";
+
+contract NodeAsAServiceTest is Base {
+    NodeAsAService public nodeAsAService;
+    ERC721Mock public nodeLicense;
+    MockERC20 public usdc;
+    
+    address public admin;
+    address public scribe;
+    address public protocolManager;
+    address public user1;
+    address public user2;
+    
+    uint256 public constant INITIAL_PRICE = 100 * 1e6; // 100 USDC (6 decimals)
+    uint256 public constant INITIAL_BALANCE = 1000 * 1e6; // 1000 USDC
+    
+    bytes32 public constant SCRIBE_ROLE = keccak256("SCRIBE_ROLE");
+    bytes32 public constant PROTOCOL_MANAGER_ROLE = keccak256("PROTOCOL_MANAGER_ROLE");
+    
+    /**
+     * @notice Sets up the test environment
+     * @dev Deploys mock contracts, initializes NodeAsAService, and sets up test accounts
+     */
+    function setUp() public override {
+        super.setUp();
+        
+        // Setup actors
+        admin = makeAddr("admin");
+        scribe = makeAddr("scribe");
+        protocolManager = makeAddr("protocolManager");
+        user1 = makeAddr("user1");
+        user2 = makeAddr("user2");
+        
+        // Deploy mock USDC
+        usdc = new MockERC20("USD Coin", "USDC", 6);
+        
+        // Deploy mock NodeLicense
+        nodeLicense = new ERC721Mock("Node License", "NODE");
+        
+        // Deploy NodeAsAService
+        NodeAsAService implementation = new NodeAsAService();
+        bytes memory data = abi.encodeWithSelector(
+            NodeAsAService.initialize.selector,
+            address(usdc),
+            address(nodeLicense),
+            admin,
+            scribe,
+            INITIAL_PRICE
+        );
+        nodeAsAService = NodeAsAService(address(new ERC1967Proxy(address(implementation), data)));
+        
+        // Setup roles
+        vm.prank(admin);
+        nodeAsAService.setProtocolManager(protocolManager);
+        
+        // Fund users with USDC
+        usdc.mint(user1, INITIAL_BALANCE);
+        usdc.mint(user2, INITIAL_BALANCE);
+    }
+    
+    /**
+     * @notice Tests the initialization of the NodeAsAService contract
+     * @dev Verifies that all contract parameters are set correctly during initialization
+     */
+    function test_Initialization() public {
+        assertEq(address(nodeAsAService.usdc()), address(usdc));
+        assertEq(address(nodeAsAService.nodeLicense()), address(nodeLicense));
+        assertEq(nodeAsAService.licensePricePerMonth(), INITIAL_PRICE);
+        assertTrue(nodeAsAService.hasRole(nodeAsAService.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(nodeAsAService.hasRole(nodeAsAService.SCRIBE_ROLE(), scribe));
+        assertTrue(nodeAsAService.hasRole(nodeAsAService.PROTOCOL_MANAGER_ROLE(), protocolManager));
+    }
+    
+    /**
+     * @notice Tests the payment for node services functionality
+     * @dev Verifies that users can pay for node services and payment records are created correctly
+     */
+    function test_PayForNodeServices() public {
+        uint256 licenseCount = 2;
+        uint256 duration = 30 days;
+        bytes32 subnetId = bytes32("test-subnet");
+        
+        // Approve USDC spending
+        vm.prank(user1);
+        usdc.approve(address(nodeAsAService), type(uint256).max);
+        
+        // Calculate expected payment
+        uint256 expectedPayment = nodeAsAService.calculateRequiredPayment(licenseCount, duration);
+        
+        // Pay for services
+        vm.prank(user1);
+        nodeAsAService.payForNodeServices(licenseCount, duration, subnetId);
+        
+        // Verify payment record
+        NodeAsAService.PaymentRecord[] memory records = nodeAsAService.getUserPaymentRecords(user1);
+        assertEq(records.length, 1);
+        NodeAsAService.PaymentRecord memory record = records[0];
+        assertEq(record.user, user1);
+        assertEq(record.licenseCount, licenseCount);
+        assertEq(record.subnetId, subnetId);
+        assertEq(record.totalCumulativeDurationInSeconds, duration);
+        assertEq(record.totalAmountPaidInUSDC, expectedPayment);
+        assertEq(record.pricePerMonthAtPayment, INITIAL_PRICE);
+    }
+    
+    /**
+     * @notice Tests the token assignment functionality
+     * @dev Verifies that scribes can assign node IDs to token IDs in payment records
+     */
+    function test_AddTokenAssignments() public {
+        // First create a payment record
+        vm.startPrank(user1);
+        usdc.approve(address(nodeAsAService), type(uint256).max);
+        nodeAsAService.payForNodeServices(2, 30 days, bytes32("test-subnet"));
+        vm.stopPrank();
+        
+        // Mint some tokens
+        uint256 tokenId1 = nodeLicense.mint(user1);
+        uint256 tokenId2 = nodeLicense.mint(user1);
+        
+        // Add token assignments
+        uint256[] memory tokenIds = new uint256[](2);
+        bytes[] memory nodeIds = new bytes[](2);
+        tokenIds[0] = tokenId1;
+        tokenIds[1] = tokenId2;
+        nodeIds[0] = "node1";
+        nodeIds[1] = "node2";
+        
+        vm.prank(scribe);
+        nodeAsAService.addTokenAssignments(user1, 0, tokenIds, nodeIds);
+        
+        // Verify assignments using getNodeIdForToken
+        bytes memory nodeId1 = nodeAsAService.getNodeIdForToken(user1, 0, tokenId1);
+        bytes memory nodeId2 = nodeAsAService.getNodeIdForToken(user1, 0, tokenId2);
+        assertEq(string(nodeId1), "node1");
+        assertEq(string(nodeId2), "node2");
+    }
+    
+    /**
+     * @notice Tests the node ID update functionality
+     * @dev Verifies that scribes can update node IDs for existing token assignments
+     */
+    function test_UpdateNodeId() public {
+        // First create a payment record and add token assignment
+        vm.startPrank(user1);
+        usdc.approve(address(nodeAsAService), type(uint256).max);
+        nodeAsAService.payForNodeServices(1, 30 days, bytes32("test-subnet"));
+        vm.stopPrank();
+        
+        uint256 tokenId = nodeLicense.mint(user1);
+        
+        uint256[] memory tokenIds = new uint256[](1);
+        bytes[] memory nodeIds = new bytes[](1);
+        tokenIds[0] = tokenId;
+        nodeIds[0] = "node1";
+        
+        vm.prank(scribe);
+        nodeAsAService.addTokenAssignments(user1, 0, tokenIds, nodeIds);
+        
+        // Update nodeId
+        vm.prank(scribe);
+        nodeAsAService.updateNodeId(user1, 0, tokenId, "node1-updated");
+        
+        // Verify update
+        bytes memory nodeId = nodeAsAService.getNodeIdForToken(user1, 0, tokenId);
+        assertEq(string(nodeId), "node1-updated");
+    }
+    
+    /**
+     * @notice Tests the fund withdrawal functionality
+     * @dev Verifies that protocol managers can withdraw funds from the contract
+     */
+    function test_WithdrawFunds() public {
+        // First create a payment to add funds to the contract
+        vm.startPrank(user1);
+        usdc.approve(address(nodeAsAService), type(uint256).max);
+        nodeAsAService.payForNodeServices(1, 30 days, bytes32("test-subnet"));
+        vm.stopPrank();
+        
+        uint256 contractBalance = usdc.balanceOf(address(nodeAsAService));
+        uint256 managerBalance = usdc.balanceOf(protocolManager);
+        
+        // Withdraw funds
+        vm.prank(protocolManager);
+        nodeAsAService.withdrawFunds(contractBalance);
+        
+        // Verify withdrawal
+        assertEq(usdc.balanceOf(address(nodeAsAService)), 0);
+        assertEq(usdc.balanceOf(protocolManager), managerBalance + contractBalance);
+    }
+    
+    /**
+     * @notice Tests the license price update functionality
+     * @dev Verifies that admins can update the license price per month
+     */
+    function test_UpdateLicensePrice() public {
+        uint256 newPrice = 200 * 1e6; // 200 USDC
+        
+        vm.prank(admin);
+        nodeAsAService.setLicensePricePerMonth(newPrice);
+        
+        assertEq(nodeAsAService.licensePricePerMonth(), newPrice);
+    }
+    
+    /**
+     * @notice Tests that payment for node services reverts with zero license count
+     * @dev Verifies the MustPayForAtLeastOneLicense error is thrown
+     */
+    function test_RevertWhen_PayForNodeServices_ZeroLicenseCount() public {
+        vm.prank(user1);
+        vm.expectRevert(NodeAsAService.MustPayForAtLeastOneLicense.selector);
+        nodeAsAService.payForNodeServices(0, 30 days, bytes32("test-subnet"));
+    }
+    
+    /**
+     * @notice Tests that payment for node services reverts with zero duration
+     * @dev Verifies the DurationMustBeGreaterThanZero error is thrown
+     */
+    function test_RevertWhen_PayForNodeServices_ZeroDuration() public {
+        vm.prank(user1);
+        vm.expectRevert(NodeAsAService.DurationMustBeGreaterThanZero.selector);
+        nodeAsAService.payForNodeServices(1, 0, bytes32("test-subnet"));
+    }
+    
+    /**
+     * @notice Tests that non-scribes cannot add token assignments
+     * @dev Verifies the AccessControlUnauthorizedAccount error is thrown
+     */
+    function test_RevertWhen_AddTokenAssignments_NotScribe() public {
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user1, SCRIBE_ROLE));
+        nodeAsAService.addTokenAssignments(user1, 0, new uint256[](1), new bytes[](1));
+    }
+    
+    /**
+     * @notice Tests that non-scribes cannot update node IDs
+     * @dev Verifies the AccessControlUnauthorizedAccount error is thrown
+     */
+    function test_RevertWhen_UpdateNodeId_NotScribe() public {
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user1, SCRIBE_ROLE));
+        nodeAsAService.updateNodeId(user1, 0, 1, bytes("node1"));
+    }
+    
+    /**
+     * @notice Tests that non-protocol managers cannot withdraw funds
+     * @dev Verifies the AccessControlUnauthorizedAccount error is thrown
+     */
+    function test_RevertWhen_WithdrawFunds_NotProtocolManager() public {
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, user1, PROTOCOL_MANAGER_ROLE));
+        nodeAsAService.withdrawFunds(100);
+    }
+
+    /**
+     * @notice Tests that payment for node services reverts with too many licenses
+     * @dev Verifies the TooManyLicenses error is thrown when license count exceeds 100
+     */
+    function test_RevertWhen_PayForNodeServices_TooManyLicenses() public {
+        vm.prank(user1);
+        vm.expectRevert(NodeAsAService.TooManyLicenses.selector);
+        nodeAsAService.payForNodeServices(101, 30 days, bytes32("test-subnet"));
+    }
+
+    /**
+     * @notice Tests that payment for node services reverts with insufficient balance
+     * @dev Verifies the InsufficientBalance error is thrown when user has insufficient USDC
+     */
+    function test_RevertWhen_PayForNodeServices_InsufficientBalance() public {
+        vm.prank(user2);
+        // Try to pay for a large number of licenses to exceed balance
+        vm.expectRevert(NodeAsAService.InsufficientBalance.selector);
+        nodeAsAService.payForNodeServices(100, 30 days, bytes32("test-subnet"));
+    }
+
+    /**
+     * @notice Tests that payment for node services reverts with transfer failure
+     * @dev Verifies the TransferFailed error is thrown when USDC transfer fails
+     */
+    function test_RevertWhen_PayForNodeServices_TransferFailed() public {
+        // First approve spending
+        vm.startPrank(user1);
+        usdc.approve(address(nodeAsAService), type(uint256).max);
+        vm.stopPrank();
+
+        // Set transfer to fail
+        usdc.setTransferShouldFail(true);
+
+        vm.prank(user1);
+        vm.expectRevert(NodeAsAService.TransferFailed.selector);
+        nodeAsAService.payForNodeServices(1, 30 days, bytes32("test-subnet"));
+    }
+
+    /**
+     * @notice Tests that token assignment reverts with empty token IDs array
+     * @dev Verifies the EmptyTokenIds error is thrown
+     */
+    function test_RevertWhen_AddTokenAssignments_EmptyTokenIds() public {
+        vm.prank(scribe);
+        vm.expectRevert(NodeAsAService.EmptyTokenIds.selector);
+        nodeAsAService.addTokenAssignments(user1, 0, new uint256[](0), new bytes[](0));
+    }
+
+    /**
+     * @notice Tests that token assignment reverts with token ID not found
+     * @dev Verifies the TokenIdNotFound error is thrown
+     */
+    function test_RevertWhen_UpdateNodeId_TokenIdNotFound() public {
+        // First create a payment record
+        vm.startPrank(user1);
+        usdc.approve(address(nodeAsAService), type(uint256).max);
+        nodeAsAService.payForNodeServices(1, 30 days, bytes32("test-subnet"));
+        vm.stopPrank();
+
+        // Try to update a non-existent token ID
+        vm.prank(scribe);
+        vm.expectRevert(NodeAsAService.TokenIdNotFound.selector);
+        nodeAsAService.updateNodeId(user1, 0, 999, bytes("node1")); // Non-existent token ID
+    }
+
+    /**
+     * @notice Tests that token assignment reverts with token ID/node ID mismatch
+     * @dev Verifies the TokenIdNodeIdMismatch error is thrown
+     */
+    function test_RevertWhen_AddTokenAssignments_TokenIdNodeIdMismatch() public {
+        uint256[] memory tokenIds = new uint256[](1);
+        bytes[] memory nodeIds = new bytes[](2); // Different length
+        vm.prank(scribe);
+        vm.expectRevert(NodeAsAService.TokenIdNodeIdMismatch.selector);
+        nodeAsAService.addTokenAssignments(user1, 0, tokenIds, nodeIds);
+    }
+
+    /**
+     * @notice Tests that token assignment reverts with invalid payment record index
+     * @dev Verifies the InvalidPaymentRecordIndex error is thrown
+     */
+    function test_RevertWhen_AddTokenAssignments_InvalidPaymentRecordIndex() public {
+        vm.prank(scribe);
+        vm.expectRevert(NodeAsAService.InvalidPaymentRecordIndex.selector);
+        nodeAsAService.addTokenAssignments(user1, 1, new uint256[](1), new bytes[](1)); // Non-existent index
+    }
+
+    /**
+     * @notice Tests that withdrawal reverts with zero amount
+     * @dev Verifies the AmountMustBeGreaterThanZero error is thrown
+     */
+    function test_RevertWhen_WithdrawFunds_ZeroAmount() public {
+        vm.prank(protocolManager);
+        vm.expectRevert(NodeAsAService.AmountMustBeGreaterThanZero.selector);
+        nodeAsAService.withdrawFunds(0);
+    }
+
+    /**
+     * @notice Tests that withdrawal reverts with insufficient contract balance
+     * @dev Verifies the InsufficientContractBalance error is thrown
+     */
+    function test_RevertWhen_WithdrawFunds_InsufficientBalance() public {
+        vm.prank(protocolManager);
+        vm.expectRevert(NodeAsAService.InsufficientContractBalance.selector);
+        nodeAsAService.withdrawFunds(1); // Try to withdraw when contract has no balance
+    }
+
+    /**
+     * @notice Tests that license price update reverts with zero price
+     * @dev Verifies the InvalidPrice error is thrown
+     */
+    function test_RevertWhen_UpdateLicensePrice_ZeroPrice() public {
+        vm.prank(admin);
+        vm.expectRevert(NodeAsAService.InvalidPrice.selector);
+        nodeAsAService.setLicensePricePerMonth(0);
+    }
+
+    /**
+     * @notice Tests setting a new scribe
+     * @dev Verifies that admin can set a new scribe and the role is granted correctly
+     */
+    function test_SetNewScribe() public {
+        address newScribe = makeAddr("newScribe");
+        vm.prank(admin);
+        nodeAsAService.setContractScribe(newScribe);
+        assertTrue(nodeAsAService.hasRole(nodeAsAService.SCRIBE_ROLE(), newScribe));
+    }
+
+    /**
+     * @notice Tests setting a new protocol manager
+     * @dev Verifies that admin can set a new protocol manager and the role is granted correctly
+     */
+    function test_SetNewProtocolManager() public {
+        address newManager = makeAddr("newManager");
+        vm.prank(admin);
+        nodeAsAService.setProtocolManager(newManager);
+        assertTrue(nodeAsAService.hasRole(nodeAsAService.PROTOCOL_MANAGER_ROLE(), newManager));
+    }
+
+    /**
+     * @notice Tests that setting scribe reverts with zero address
+     * @dev Verifies the ZeroAddress error is thrown
+     */
+    function test_RevertWhen_SetScribe_ZeroAddress() public {
+        vm.prank(admin);
+        vm.expectRevert(NodeAsAService.ZeroAddress.selector);
+        nodeAsAService.setContractScribe(address(0));
+    }
+
+    /**
+     * @notice Tests that setting protocol manager reverts with zero address
+     * @dev Verifies the ZeroAddress error is thrown
+     */
+    function test_RevertWhen_SetProtocolManager_ZeroAddress() public {
+        vm.prank(admin);
+        vm.expectRevert(NodeAsAService.ZeroAddress.selector);
+        nodeAsAService.setProtocolManager(address(0));
+    }
+
+    /**
+     * @notice Tests that multiple tokens can be assigned to the same node ID
+     * @dev Verifies that the same node ID can be used for different token IDs
+     */
+    function test_MultipleTokensPerNodeId() public {
+        // First create a payment record
+        vm.startPrank(user1);
+        usdc.approve(address(nodeAsAService), type(uint256).max);
+        nodeAsAService.payForNodeServices(2, 30 days, bytes32("test-subnet"));
+        vm.stopPrank();
+        
+        // Mint two tokens
+        uint256 tokenId1 = nodeLicense.mint(user1);
+        uint256 tokenId2 = nodeLicense.mint(user1);
+        
+        // Assign both tokens to the same node ID
+        uint256[] memory tokenIds = new uint256[](2);
+        bytes[] memory nodeIds = new bytes[](2);
+        tokenIds[0] = tokenId1;
+        tokenIds[1] = tokenId2;
+        nodeIds[0] = "same-node";
+        nodeIds[1] = "same-node";
+        
+        vm.prank(scribe);
+        nodeAsAService.addTokenAssignments(user1, 0, tokenIds, nodeIds);
+        
+        // Verify both tokens have the same node ID
+        bytes memory nodeId1 = nodeAsAService.getNodeIdForToken(user1, 0, tokenId1);
+        bytes memory nodeId2 = nodeAsAService.getNodeIdForToken(user1, 0, tokenId2);
+        assertEq(string(nodeId1), "same-node");
+        assertEq(string(nodeId2), "same-node");
+    }
+} 

--- a/tests/NodeAsAService.t.sol
+++ b/tests/NodeAsAService.t.sol
@@ -145,7 +145,7 @@ contract NodeAsAServiceTest is Base {
 
     /**
      * @notice Tests that payment for node services reverts with transfer failure
-     * @dev Verifies the TransferFailed error is thrown when USDC transfer fails
+     * @dev Verifies that the SafeERC20 error is thrown when USDC transfer fails
      */
     function test_RevertWhen_PayForNodeServices_TransferFailed() public {
         // First approve spending

--- a/tests/mocks/MockERC20.sol
+++ b/tests/mocks/MockERC20.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.25;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    uint8 private _decimals;
+    bool private _transferShouldFail;
+
+    constructor(
+        string memory name,
+        string memory symbol,
+        uint8 decimals_
+    ) ERC20(name, symbol) {
+        _decimals = decimals_;
+        _transferShouldFail = false;
+    }
+
+    function setTransferShouldFail(bool shouldFail) public {
+        _transferShouldFail = shouldFail;
+    }
+
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
+        if (_transferShouldFail) {
+            return false;
+        }
+        return super.transfer(to, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
+        if (_transferShouldFail) {
+            return false;
+        }
+        return super.transferFrom(from, to, amount);
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _decimals;
+    }
+} 


### PR DESCRIPTION
tried to create a staking contract that will keep track of what the user is paying us for (USDC)

one transaction to pay for X license all for the same duration length, delimitated by months. X can be no larger than 100.

the price per node is set in the contract but can be easily changed with a transaction, this is for verification to make sure they transfer the correct amount of funds. I know we talked about this not being in the contracts, but changing this in the contract seems just as simple as in the UI and adds a security aspect.

I do track the license tokenID<>nodeID relationship per user - mainly because I didnt see an easy way to get this from the nftstakingmanager? and I know we will need this in the FE and an easy way to see this is we are forgoing the supabase to track this relationship.

I updated the manual flow architecture to accommodate waht we are tracking/doing in this contract: https://app.excalidraw.com/s/4lIY3DT4YH4/2K4AIhCeqRp

should be noted I vibe coded the tests so Ill have to recheck those in the mornin but they are passing