### PR TITLE
Use EnumerableSet for operator approvals

### DIFF
--- a/contracts/tokens/NodeLicense.sol
+++ b/contracts/tokens/NodeLicense.sol
@@ -10,6 +10,8 @@ import { UUPSUpgradeable } from
   "@openzeppelin-contracts-upgradeable-5.3.0/proxy/utils/UUPSUpgradeable.sol";
 import { ERC721EnumerableUpgradeable } from
   "@openzeppelin-contracts-upgradeable-5.3.0/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import { EnumerableSet } from "@openzeppelin-contracts-5.3.0/utils/structs/EnumerableSet.sol";
+
 
 interface INFTStakingManager {
   function getTokenLockedBy(uint256 tokenId) external view returns (bytes32);
@@ -69,6 +71,8 @@ contract NodeLicense is
   AccessControlDefaultAdminRulesUpgradeable,
   UUPSUpgradeable
 {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
   bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
   string private _baseTokenURI;
@@ -77,7 +81,7 @@ contract NodeLicense is
   address private _nftStakingManager;
 
   mapping(uint256 tokenId => address) private _tokenDelegateApprovals;
-  mapping(address owner => mapping(address operator => bool)) private _delegateOperatorApprovals;
+  mapping(address => EnumerableSet.AddressSet) private _delegateOperatorApprovals;
 
   event BaseURIUpdated(string newBaseURI);
   event NFTStakingManagerUpdated(address indexed oldManager, address indexed newManager);
@@ -180,12 +184,17 @@ contract NodeLicense is
       revert ERC721InvalidOperator(operator);
     }
 
-    _delegateOperatorApprovals[owner][operator] = approved;
+    if (approved) {
+      _delegateOperatorApprovals[owner].add(operator);
+    } else {
+      _delegateOperatorApprovals[owner].remove(operator);
+    }
+
     emit DelegateApprovalForAll(owner, operator, approved);
   }
 
   function isDelegationApprovedForAll(address owner, address operator) public view returns (bool) {
-    return _delegateOperatorApprovals[owner][operator];
+    return _delegateOperatorApprovals[owner].contains(operator);
   }
 
   function getDelegationApproval(uint256 tokenId) public view returns (address) {
@@ -261,5 +270,9 @@ contract NodeLicense is
 
   function getUnlockTime() external view returns (uint32) {
     return _lockedUntil;
+  }
+
+  function getDelegateOperatorsForOwner(address owner) external view returns (address[] memory) {
+    return _delegateOperatorApprovals[owner].values();
   }
 }

--- a/tests/NodeLicense.t.sol
+++ b/tests/NodeLicense.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.25;
 
 import { NodeLicense, NodeLicenseSettings } from "../contracts/tokens/NodeLicense.sol";
 import { MockStakingManager } from "./mocks/MockStakingManager.sol";
+import { IAccessControl } from "@openzeppelin-contracts-5.3.0/access/IAccessControl.sol";
+import { IERC721Errors } from "@openzeppelin-contracts-5.3.0/interfaces/draft-IERC6093.sol";
 
 import { ERC1967Proxy } from
   "../dependencies/@openzeppelin-contracts-5.3.0/proxy/ERC1967/ERC1967Proxy.sol";
@@ -276,11 +278,163 @@ contract NodeLicenseTest is Base {
     uint32 newUnlockTime = uint32(block.timestamp + 1 days);
 
     // Try to set unlock time as non-admin
-    vm.prank(user1);
-    vm.expectRevert();
+    vm.startPrank(user1);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IAccessControl.AccessControlUnauthorizedAccount.selector, user1, nodeLicense.DEFAULT_ADMIN_ROLE()
+      )
+    );
     nodeLicense.setUnlockTime(newUnlockTime);
+    vm.stopPrank();
+
 
     // Verify unlock time was not changed
     assertEq(nodeLicense.getUnlockTime(), 0);
+  }
+
+  // --- Tests for Delegation Approval ---
+
+  function test_ApproveDelegation_And_GetDelegationApproval() public {
+    // Mint a token to user1
+    vm.prank(minter);
+    uint256 tokenId = nodeLicense.mint(user1);
+
+    // user1 approves user2 for this specific token
+    vm.prank(user1);
+    vm.expectEmit(true, true, true, true);
+    emit NodeLicense.DelegateApproval(user1, user2, tokenId);
+    nodeLicense.approveDelegation(user2, tokenId);
+
+    // Verify user2 is the approved delegate for the token
+    assertEq(nodeLicense.getDelegationApproval(tokenId), user2, "User2 should be approved delegate");
+
+    // user1 changes approval to address(0) (clearing it)
+    vm.prank(user1);
+    vm.expectEmit(true, true, true, true);
+    emit NodeLicense.DelegateApproval(user1, address(0), tokenId);
+    nodeLicense.approveDelegation(address(0), tokenId);
+    assertEq(
+      nodeLicense.getDelegationApproval(tokenId),
+      address(0),
+      "Delegation approval should be cleared"
+    );
+  }
+
+  function test_ApproveDelegation_NotOwner_Reverts() public {
+    // Mint a token to user1
+    vm.prank(minter);
+    uint256 tokenId = nodeLicense.mint(user1);
+
+    // user2 (not owner) tries to approve user1 for the token
+    vm.prank(user2);
+    vm.expectRevert(abi.encodeWithSelector(IERC721Errors.ERC721InvalidApprover.selector, user2));
+    nodeLicense.approveDelegation(user1, tokenId);
+  }
+
+  function test_GetDelegationApproval_NonExistentToken_Reverts() public {
+    // Mint token 1 to user1 so that token IDs start from 1
+    vm.prank(minter);
+    nodeLicense.mint(user1);
+
+    // Try to get approval for a non-existent token (e.g., tokenId 99)
+    // _requireOwned inside getDelegationApproval should revert
+    uint256 nonExistentTokenId = 99;
+    vm.expectRevert(
+      abi.encodeWithSelector(IERC721Errors.ERC721NonexistentToken.selector, nonExistentTokenId)
+    );
+    nodeLicense.getDelegationApproval(nonExistentTokenId);
+  }
+  
+  function test_RemoveDelegaation_NonExistantDelegation() public {
+    address operator = makeAddr("operator");
+
+    vm.prank(minter);
+    nodeLicense.mint(user1);
+    
+    vm.prank(user1);
+    nodeLicense.setDelegationApprovalForAll(operator, false);
+    
+    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator), "operator is not approved for user1");
+  }
+
+  function test_SetDelegationApprovalForAll_And_IsDelegationApprovedForAll() public {
+    address operator1 = user2; // Using user2 as operator1 for clarity
+    address operator2 = makeAddr("operator2");
+    address operator3 = makeAddr("operator3");
+
+    // Initially, no operators are approved for user1
+    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator1), "Initially operator1 not approved for user1");
+    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator2), "Initially operator2 not approved for user1");
+    address[] memory initialOperators = nodeLicense.getDelegateOperatorsForOwner(user1);
+    assertEq(initialOperators.length, 0, "Initially no operators for user1");
+
+    // user1 approves operator1
+    vm.prank(user1);
+    vm.expectEmit(true, true, true, true);
+    emit NodeLicense.DelegateApprovalForAll(user1, operator1, true);
+    nodeLicense.setDelegationApprovalForAll(operator1, true);
+
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator1), "operator1 should be approved for user1");
+    address[] memory operatorsAfterOp1 = nodeLicense.getDelegateOperatorsForOwner(user1);
+    assertEq(operatorsAfterOp1.length, 1, "Should have 1 operator after approving operator1");
+    assertEq(operatorsAfterOp1[0], operator1, "The operator should be operator1");
+
+    // user1 approves operator2
+    vm.prank(user1);
+    vm.expectEmit(true, true, true, true);
+    emit NodeLicense.DelegateApprovalForAll(user1, operator2, true);
+    nodeLicense.setDelegationApprovalForAll(operator2, true);
+
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator1), "operator1 should still be approved for user1");
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should now be approved for user1");
+    address[] memory operatorsAfterOp2 = nodeLicense.getDelegateOperatorsForOwner(user1);
+    assertEq(operatorsAfterOp2.length, 2, "Should have 2 operators after approving operator2");
+    // Note: EnumerableSet does not guarantee order, so we check for presence
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator1) && nodeLicense.isDelegationApprovedForAll(user1, operator2), "Both operators should be in the set");
+
+    // user1 revokes operator1
+    vm.prank(user1);
+    vm.expectEmit(true, true, true, true);
+    emit NodeLicense.DelegateApprovalForAll(user1, operator1, false);
+    nodeLicense.setDelegationApprovalForAll(operator1, false);
+
+    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator1), "operator1 should NOT be approved after revocation");
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should still be approved");
+    address[] memory operatorsAfterOp1Revoke = nodeLicense.getDelegateOperatorsForOwner(user1);
+    assertEq(operatorsAfterOp1Revoke.length, 1, "Should have 1 operator after revoking operator1");
+    assertEq(operatorsAfterOp1Revoke[0], operator2, "The remaining operator should be operator2");
+
+    // user1 approves operator3 (to test order with operator2 still present)
+    vm.prank(user1);
+    nodeLicense.setDelegationApprovalForAll(operator3, true);
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should be approved");
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should still be approved");
+    assertEq(nodeLicense.getDelegateOperatorsForOwner(user1).length, 2, "Should have 2 operators");
+
+    // user1 revokes operator2
+    vm.prank(user1);
+    nodeLicense.setDelegationApprovalForAll(operator2, false);
+    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should be revoked");
+    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should still be approved");
+    address[] memory operatorsAfterOp2Revoke = nodeLicense.getDelegateOperatorsForOwner(user1);
+    assertEq(operatorsAfterOp2Revoke.length, 1, "Should have 1 operator after revoking operator2");
+    assertEq(operatorsAfterOp2Revoke[0], operator3, "The remaining operator should be operator3");
+    
+    // Revoke last operator (operator3)
+    vm.prank(user1);
+    nodeLicense.setDelegationApprovalForAll(operator3, false);
+    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should be revoked");
+    assertEq(nodeLicense.getDelegateOperatorsForOwner(user1).length, 0, "Should have 0 operators");
+
+    // Check approvals for a different owner (no interference)
+    assertFalse(nodeLicense.isDelegationApprovedForAll(operator1, operator2), "operator1 should not have approved operator2 for itself");
+  }
+
+  function test_SetDelegationApprovalForAll_RevertOnZeroAddressOperator() public {
+    vm.prank(user1);
+    vm.expectRevert(
+      abi.encodeWithSelector(IERC721Errors.ERC721InvalidOperator.selector, address(0))
+    );
+    nodeLicense.setDelegationApprovalForAll(address(0), true);
   }
 }


### PR DESCRIPTION
This will allow us to get all the approvals for a user from a frontend dashboard. We will have to get all the user addresses and then call this function to get all of their approvals.

We can get the token holders by way of the ERC721Enumerable