### PR TITLE
Remove revert for zero address NFTStakingManager in NodeLicense

### DIFF
--- a/contracts/tokens/NodeLicense.sol
+++ b/contracts/tokens/NodeLicense.sol
@@ -208,7 +208,6 @@ contract NodeLicense is
   }
 
   function setNFTStakingManager(address nftStakingManager) public onlyRole(DEFAULT_ADMIN_ROLE) {
-    if (nftStakingManager == address(0)) revert ZeroAddress();
     emit NFTStakingManagerUpdated(_nftStakingManager, nftStakingManager);
     _nftStakingManager = nftStakingManager;
   }


### PR DESCRIPTION
https://github.com/multisig-labs/validation-managers/issues/34

don't revert for zero address when setting NFTStakingManager in the NodeLicense. This will have the effect of allowing transfers if an admin removes the contract setting. 

