### PR TITLE
Add owner mapping for validations and delegations

### DIFF
--- a/contracts/NFTStakingManager.sol
+++ b/contracts/NFTStakingManager.sol
@@ -1077,6 +1077,18 @@ contract NFTStakingManager is
     NFTStakingManagerStorage storage $ = _getNFTStakingManagerStorage();
     return $.delegations[delegationID].claimableRewardsPerEpoch.get(uint256(epoch));
   }
+  
+  /// @notice Gets tokenIds that have been minted rewards for a given epoch
+  ///
+  /// @param epoch The rewards epoch to fetch tokenIds
+  ///
+  /// @return tokenIds the tokenIds that have been minted rewards
+  function getRewardsMintedForEpoch(uint32 epoch) external view returns (uint256[] memory) {
+    NFTStakingManagerStorage storage $ = _getNFTStakingManagerStorage();
+    return $.epochs[epoch].rewardsMintedFor.values();
+  }
+
+  // EnumerableSet.UintSet rewardsMintedFor; // which tokenids have rewards been minted for
 
   /// @notice Gets the current settings for the NFT Staking Manager
   ///

--- a/contracts/NFTStakingManager.sol
+++ b/contracts/NFTStakingManager.sol
@@ -874,7 +874,6 @@ contract NFTStakingManager is
       emit RewardsClaimed(claimedEpochNumbers[i], id, rewardsAmounts[i]);
     }
 
-    // DO NOT SEND ETH HERE. The public functions will do it.
     return (totalRewardsToTransfer, claimedEpochNumbers);
   }
 
@@ -897,13 +896,11 @@ contract NFTStakingManager is
     (totalRewards, claimedEpochNumbers) =
       _claimRewardsInternal(delegation.claimableRewardsPerEpoch, delegationID, maxEpochs);
 
-    // Conditionally remove from delegationsByOwner if all rewards claimed and delegation ended
     if (
       delegation.claimableRewardsPerEpoch.length() == 0 && delegation.endEpoch != 0
         && delegation.endEpoch < getEpochByTimestamp(block.timestamp)
     ) {
       $.delegationsByOwner[delegation.owner].remove(delegationID);
-      // Optionally, to free up more storage: delete $.delegations[delegationID];
     }
 
     // Send rewards last
@@ -929,13 +926,11 @@ contract NFTStakingManager is
     (totalRewards, claimedEpochNumbers) =
       _claimRewardsInternal(validation.claimableRewardsPerEpoch, validationID, maxEpochs);
 
-    // Conditionally remove from validationsByOwner if all rewards claimed and validation ended
     if (
       validation.claimableRewardsPerEpoch.length() == 0 && validation.endEpoch != 0
         && validation.endEpoch <= getEpochByTimestamp(block.timestamp)
     ) {
       $.validationsByOwner[validation.owner].remove(validationID);
-      // Optionally, to free up more storage: delete $.validations[validationID];
     }
 
     // Send rewards last

--- a/contracts/NFTStakingManager.sol
+++ b/contracts/NFTStakingManager.sol
@@ -73,7 +73,8 @@ enum DelegatorStatus {
   Unknown,
   PendingAdded,
   Active,
-  PendingRemoved
+  PendingRemoved,
+  Removed
 }
 
 /// @notice Delegator information
@@ -431,6 +432,7 @@ contract NFTStakingManager is
 
     if (validation.claimableRewardsPerEpoch.length() == 0) {
       $.validationsByOwner[validation.owner].remove(validationID);
+      delete $.validations[validationID];
     }
 
     emit CompletedValidatorRemoval(validationID);
@@ -673,11 +675,14 @@ contract NFTStakingManager is
       }
     }
 
+    delegation.status = DelegatorStatus.Removed;
+
     if (delegation.claimableRewardsPerEpoch.length() == 0) {
       $.delegationsByOwner[delegation.owner].remove(delegationID);
+      delete $.delegations[delegationID];
     }
 
-    // we never delete the delegation so that the user can claim rewards whenever
+
     _unlockTokens(delegationID, delegation.tokenIDs);
     emit CompletedDelegatorRemoval(validationID, delegationID, nonce);
     return delegationID;
@@ -861,6 +866,7 @@ contract NFTStakingManager is
         && validation.endEpoch <= getEpochByTimestamp(block.timestamp)
     ) {
       $.validationsByOwner[validation.owner].remove(validationID);
+      delete $.validations[validationID];
     }
 
     // Send rewards last
@@ -892,6 +898,7 @@ contract NFTStakingManager is
         && delegation.endEpoch < getEpochByTimestamp(block.timestamp)
     ) {
       $.delegationsByOwner[delegation.owner].remove(delegationID);
+      delete $.delegations[delegationID];
     }
 
     // Send rewards last

--- a/contracts/NFTStakingManager.sol
+++ b/contracts/NFTStakingManager.sol
@@ -846,7 +846,7 @@ contract NFTStakingManager is
   ///
   /// @return totalRewardsToTransfer The total rewards to claim
   /// @return claimedEpochNumbers The epoch numbers that were claimed
-  function _claimRewardsInternal(
+  function _claimRewards(
     EnumerableMap.UintToUintMap storage rewardsMap,
     bytes32 id,
     uint32 maxEpochs
@@ -884,7 +884,7 @@ contract NFTStakingManager is
   ///
   /// @return totalRewards The total rewards to claim
   /// @return claimedEpochNumbers The epoch numbers that were claimed
-  function claimRewards(bytes32 delegationID, uint32 maxEpochs)
+  function claimDelegatorRewards(bytes32 delegationID, uint32 maxEpochs)
     external
     returns (uint256 totalRewards, uint32[] memory claimedEpochNumbers)
   {
@@ -894,7 +894,7 @@ contract NFTStakingManager is
     if (delegation.owner != _msgSender()) revert UnauthorizedOwner();
 
     (totalRewards, claimedEpochNumbers) =
-      _claimRewardsInternal(delegation.claimableRewardsPerEpoch, delegationID, maxEpochs);
+      _claimRewards(delegation.claimableRewardsPerEpoch, delegationID, maxEpochs);
 
     if (
       delegation.claimableRewardsPerEpoch.length() == 0 && delegation.endEpoch != 0
@@ -924,7 +924,7 @@ contract NFTStakingManager is
     if (validation.owner != _msgSender()) revert UnauthorizedOwner();
 
     (totalRewards, claimedEpochNumbers) =
-      _claimRewardsInternal(validation.claimableRewardsPerEpoch, validationID, maxEpochs);
+      _claimRewards(validation.claimableRewardsPerEpoch, validationID, maxEpochs);
 
     if (
       validation.claimableRewardsPerEpoch.length() == 0 && validation.endEpoch != 0

--- a/contracts/tokens/NodeLicense.sol
+++ b/contracts/tokens/NodeLicense.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.25;
 
+import { EnumerableSet } from "@openzeppelin-contracts-5.3.0/utils/structs/EnumerableSet.sol";
 import { AccessControlDefaultAdminRulesUpgradeable } from
   "@openzeppelin-contracts-upgradeable-5.3.0/access/extensions/AccessControlDefaultAdminRulesUpgradeable.sol";
 import { Initializable } from
@@ -10,8 +11,6 @@ import { UUPSUpgradeable } from
   "@openzeppelin-contracts-upgradeable-5.3.0/proxy/utils/UUPSUpgradeable.sol";
 import { ERC721EnumerableUpgradeable } from
   "@openzeppelin-contracts-upgradeable-5.3.0/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
-import { EnumerableSet } from "@openzeppelin-contracts-5.3.0/utils/structs/EnumerableSet.sol";
-
 
 interface INFTStakingManager {
   function getTokenLockedBy(uint256 tokenId) external view returns (bytes32);

--- a/tests/NFTStakingManager.t.sol
+++ b/tests/NFTStakingManager.t.sol
@@ -1185,6 +1185,22 @@ contract NFTStakingManagerTest is Base {
     assertEq(totalRewards, epochRewards * 2);
     assertEq(claimedEpochNumbers.length, 2);
   }
+  
+  function test_getRewardsMintedForEpoch() public {
+    (bytes32 validationID, ) = _createValidator();
+    _createDelegation(validationID, 1);
+    
+    uint32 epoch = nftStakingManager.getEpochByTimestamp(block.timestamp);
+    _warpToGracePeriod(epoch);
+    _processUptimeProof(validationID, EPOCH_DURATION);
+    _warpAfterGracePeriod(epoch);
+
+    _mintOneReward(validationID, epoch);
+
+    uint256[] memory tokenIDs = nftStakingManager.getRewardsMintedForEpoch(epoch);
+    assertEq(tokenIDs.length, 1);
+  }
+  
 
   ///
   /// NONCE TESTS

--- a/tests/NFTStakingManager.t.sol
+++ b/tests/NFTStakingManager.t.sol
@@ -1266,12 +1266,12 @@ contract NFTStakingManagerTest is Base {
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegator1).length,
       1,
-      "A: Initial delegation count should be 1"
+      "Initial delegation count should be 1"
     );
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegator1)[0],
       delegationID1,
-      "A: Initial delegation ID mismatch"
+      "Initial delegation ID mismatch"
     );
 
     uint32 rewardsEpoch = nftStakingManager.getEpochByTimestamp(block.timestamp);
@@ -1294,12 +1294,10 @@ contract NFTStakingManagerTest is Base {
 
     vm.prank(delegator1);
     (uint256 d1TotalRewards,) = nftStakingManager.claimRewards(delegationID1, 1);
-    assertGt(d1TotalRewards, 0, "A: Should have claimed some rewards");
+    assertGt(d1TotalRewards, 0, "Should have claimed some rewards");
 
     assertEq(
-      nftStakingManager.getDelegationsByOwner(delegator1).length,
-      0,
-      "A: Delegation should be removed"
+      nftStakingManager.getDelegationsByOwner(delegator1).length, 0, "Delegation should be removed"
     );
   }
 
@@ -1316,7 +1314,7 @@ contract NFTStakingManagerTest is Base {
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegator2).length,
       1,
-      "B: Initial delegation count should be 1"
+      "Initial delegation count should be 1"
     );
 
     rewardsEpoch = nftStakingManager.getEpochByTimestamp(block.timestamp);
@@ -1336,17 +1334,17 @@ contract NFTStakingManagerTest is Base {
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegator2).length,
       1,
-      "B: Delegation should STILL be present as rewards not claimed"
+      "Delegation should STILL be present as rewards not claimed"
     );
 
     vm.prank(delegator2);
     (uint256 d2TotalRewards,) = nftStakingManager.claimRewards(delegationID2, 1);
-    assertGt(d2TotalRewards, 0, "B: Should have claimed some rewards");
+    assertGt(d2TotalRewards, 0, "Should have claimed some rewards");
 
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegator2).length,
       0,
-      "B: Delegation should be removed after claiming rewards"
+      "Delegation should be removed after claiming rewards"
     );
   }
 
@@ -1362,7 +1360,7 @@ contract NFTStakingManagerTest is Base {
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegator3).length,
       1,
-      "C: Initial delegation count should be 1"
+      "Initial delegation count should be 1"
     );
 
     rewardsEpoch = nftStakingManager.getEpochByTimestamp(block.timestamp);
@@ -1373,13 +1371,13 @@ contract NFTStakingManagerTest is Base {
 
     vm.prank(delegator3);
     (uint256 d3TotalRewards,) = nftStakingManager.claimRewards(delegationID3, 1);
-    assertGt(d3TotalRewards, 0, "C: Should have claimed some rewards");
+    assertGt(d3TotalRewards, 0, "Should have claimed some rewards");
 
     // Delegation is NOT ended
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegator3).length,
       1,
-      "C: Delegation should STILL be present as it's active"
+      "Delegation should STILL be present as it's active"
     );
   }
 
@@ -1494,10 +1492,6 @@ contract NFTStakingManagerTest is Base {
   function test_DelegatorRemoval_WithRewards_DoesNotRemoveFromOwnerMapping() public {
     (bytes32 validationID, /* address validatorOwner */ ) = _createValidator();
     (bytes32 delegationID, address delegatorOwner) = _createDelegation(validationID, 1);
-
-    // No need to add prepaid credits if we are testing that delegation fee is paid to validator
-    // and delegator receives rewards minus fee. If full rewards for delegator are desired for specific test,
-    // then addPrepaidCredits. For this test, it's fine either way, as long as rewards are generated.
 
     assertEq(
       nftStakingManager.getDelegationsByOwner(delegatorOwner).length,

--- a/tests/NFTStakingManager.t.sol
+++ b/tests/NFTStakingManager.t.sol
@@ -668,7 +668,7 @@ contract NFTStakingManagerTest is Base {
 
     vm.prank(delegator);
     (uint256 totalRewards, uint32[] memory claimedEpochNumbers) =
-      nftStakingManager.claimRewards(delegationID, 2);
+      nftStakingManager.claimDelegatorRewards(delegationID, 2);
 
     assertEq(totalRewards, epochRewards * 2);
     assertEq(claimedEpochNumbers.length, 2);
@@ -920,7 +920,7 @@ contract NFTStakingManagerTest is Base {
 
       // claim rewards
       vm.prank(delegator);
-      (uint256 claimedRewards,) = nftStakingManager.claimRewards(delegationID1, 1);
+      (uint256 claimedRewards,) = nftStakingManager.claimDelegatorRewards(delegationID1, 1);
       assertEq(claimedRewards, epochRewards);
     }
 
@@ -947,7 +947,7 @@ contract NFTStakingManagerTest is Base {
 
       // Claim rewards
       vm.prank(delegator);
-      (uint256 claimedRewards,) = nftStakingManager.claimRewards(delegationID2, 1);
+      (uint256 claimedRewards,) = nftStakingManager.claimDelegatorRewards(delegationID2, 1);
 
       assertEq(claimedRewards, epochRewards);
     }
@@ -1075,7 +1075,7 @@ contract NFTStakingManagerTest is Base {
     // Claim rewards as delegator
     vm.startPrank(delegator);
     (uint256 totalRewards, uint32[] memory claimedEpochNumbers) =
-      nftStakingManager.claimRewards(delegationID, 2);
+      nftStakingManager.claimDelegatorRewards(delegationID, 2);
     vm.stopPrank();
 
     // Verify rewards (delegator gets full rewards minus delegation fee)
@@ -1102,7 +1102,7 @@ contract NFTStakingManagerTest is Base {
     address unauthorized = getActor("Unauthorized");
     vm.startPrank(unauthorized);
     vm.expectRevert(NFTStakingManager.UnauthorizedOwner.selector);
-    nftStakingManager.claimRewards(delegationID, 1);
+    nftStakingManager.claimDelegatorRewards(delegationID, 1);
     vm.stopPrank();
   }
 
@@ -1114,7 +1114,7 @@ contract NFTStakingManagerTest is Base {
     // Try to claim rewards when none exist
     vm.startPrank(delegator);
     (uint256 totalRewards, uint32[] memory claimedEpochNumbers) =
-      nftStakingManager.claimRewards(delegationID, 1);
+      nftStakingManager.claimDelegatorRewards(delegationID, 1);
     vm.stopPrank();
 
     assertEq(totalRewards, 0);
@@ -1137,7 +1137,7 @@ contract NFTStakingManagerTest is Base {
     // Claim only 2 epochs worth of rewards
     vm.startPrank(delegator);
     (uint256 totalRewards, uint32[] memory claimedEpochNumbers) =
-      nftStakingManager.claimRewards(delegationID, 2);
+      nftStakingManager.claimDelegatorRewards(delegationID, 2);
     vm.stopPrank();
 
     // Verify first two epochs were claimed
@@ -1148,7 +1148,7 @@ contract NFTStakingManagerTest is Base {
 
     // Claim remaining epoch
     vm.startPrank(delegator);
-    (totalRewards, claimedEpochNumbers) = nftStakingManager.claimRewards(delegationID, 1);
+    (totalRewards, claimedEpochNumbers) = nftStakingManager.claimDelegatorRewards(delegationID, 1);
     vm.stopPrank();
 
     // Verify last epoch was claimed
@@ -1178,7 +1178,7 @@ contract NFTStakingManagerTest is Base {
     // Claim rewards as delegator
     vm.startPrank(delegator);
     (uint256 totalRewards, uint32[] memory claimedEpochNumbers) =
-      nftStakingManager.claimRewards(delegationID, 2);
+      nftStakingManager.claimDelegatorRewards(delegationID, 2);
     vm.stopPrank();
 
     // Verify delegator gets full rewards (no delegation fee due to prepaid credits)
@@ -1293,7 +1293,7 @@ contract NFTStakingManagerTest is Base {
     vm.warp(block.timestamp + EPOCH_DURATION * 2);
 
     vm.prank(delegator1);
-    (uint256 d1TotalRewards,) = nftStakingManager.claimRewards(delegationID1, 1);
+    (uint256 d1TotalRewards,) = nftStakingManager.claimDelegatorRewards(delegationID1, 1);
     assertGt(d1TotalRewards, 0, "Should have claimed some rewards");
 
     assertEq(
@@ -1338,7 +1338,7 @@ contract NFTStakingManagerTest is Base {
     );
 
     vm.prank(delegator2);
-    (uint256 d2TotalRewards,) = nftStakingManager.claimRewards(delegationID2, 1);
+    (uint256 d2TotalRewards,) = nftStakingManager.claimDelegatorRewards(delegationID2, 1);
     assertGt(d2TotalRewards, 0, "Should have claimed some rewards");
 
     assertEq(
@@ -1370,7 +1370,7 @@ contract NFTStakingManagerTest is Base {
     _mintOneReward(validationID, rewardsEpoch);
 
     vm.prank(delegator3);
-    (uint256 d3TotalRewards,) = nftStakingManager.claimRewards(delegationID3, 1);
+    (uint256 d3TotalRewards,) = nftStakingManager.claimDelegatorRewards(delegationID3, 1);
     assertGt(d3TotalRewards, 0, "Should have claimed some rewards");
 
     // Delegation is NOT ended
@@ -1521,7 +1521,7 @@ contract NFTStakingManagerTest is Base {
 
     // Claim delegator rewards
     vm.prank(delegatorOwner);
-    (uint256 totalRewards,) = nftStakingManager.claimRewards(delegationID, 1);
+    (uint256 totalRewards,) = nftStakingManager.claimDelegatorRewards(delegationID, 1);
     assertGt(totalRewards, 0, "Delegator should have claimed rewards");
 
     assertEq(

--- a/tests/NodeLicense.t.sol
+++ b/tests/NodeLicense.t.sol
@@ -281,12 +281,13 @@ contract NodeLicenseTest is Base {
     vm.startPrank(user1);
     vm.expectRevert(
       abi.encodeWithSelector(
-        IAccessControl.AccessControlUnauthorizedAccount.selector, user1, nodeLicense.DEFAULT_ADMIN_ROLE()
+        IAccessControl.AccessControlUnauthorizedAccount.selector,
+        user1,
+        nodeLicense.DEFAULT_ADMIN_ROLE()
       )
     );
     nodeLicense.setUnlockTime(newUnlockTime);
     vm.stopPrank();
-
 
     // Verify unlock time was not changed
     assertEq(nodeLicense.getUnlockTime(), 0);
@@ -344,17 +345,19 @@ contract NodeLicenseTest is Base {
     );
     nodeLicense.getDelegationApproval(nonExistentTokenId);
   }
-  
+
   function test_RemoveDelegaation_NonExistantDelegation() public {
     address operator = makeAddr("operator");
 
     vm.prank(minter);
     nodeLicense.mint(user1);
-    
+
     vm.prank(user1);
     nodeLicense.setDelegationApprovalForAll(operator, false);
-    
-    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator), "operator is not approved for user1");
+
+    assertFalse(
+      nodeLicense.isDelegationApprovedForAll(user1, operator), "operator is not approved for user1"
+    );
   }
 
   function test_SetDelegationApprovalForAll_And_IsDelegationApprovedForAll() public {
@@ -363,8 +366,14 @@ contract NodeLicenseTest is Base {
     address operator3 = makeAddr("operator3");
 
     // Initially, no operators are approved for user1
-    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator1), "Initially operator1 not approved for user1");
-    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator2), "Initially operator2 not approved for user1");
+    assertFalse(
+      nodeLicense.isDelegationApprovedForAll(user1, operator1),
+      "Initially operator1 not approved for user1"
+    );
+    assertFalse(
+      nodeLicense.isDelegationApprovedForAll(user1, operator2),
+      "Initially operator2 not approved for user1"
+    );
     address[] memory initialOperators = nodeLicense.getDelegateOperatorsForOwner(user1);
     assertEq(initialOperators.length, 0, "Initially no operators for user1");
 
@@ -374,7 +383,10 @@ contract NodeLicenseTest is Base {
     emit NodeLicense.DelegateApprovalForAll(user1, operator1, true);
     nodeLicense.setDelegationApprovalForAll(operator1, true);
 
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator1), "operator1 should be approved for user1");
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator1),
+      "operator1 should be approved for user1"
+    );
     address[] memory operatorsAfterOp1 = nodeLicense.getDelegateOperatorsForOwner(user1);
     assertEq(operatorsAfterOp1.length, 1, "Should have 1 operator after approving operator1");
     assertEq(operatorsAfterOp1[0], operator1, "The operator should be operator1");
@@ -385,12 +397,22 @@ contract NodeLicenseTest is Base {
     emit NodeLicense.DelegateApprovalForAll(user1, operator2, true);
     nodeLicense.setDelegationApprovalForAll(operator2, true);
 
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator1), "operator1 should still be approved for user1");
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should now be approved for user1");
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator1),
+      "operator1 should still be approved for user1"
+    );
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator2),
+      "operator2 should now be approved for user1"
+    );
     address[] memory operatorsAfterOp2 = nodeLicense.getDelegateOperatorsForOwner(user1);
     assertEq(operatorsAfterOp2.length, 2, "Should have 2 operators after approving operator2");
     // Note: EnumerableSet does not guarantee order, so we check for presence
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator1) && nodeLicense.isDelegationApprovedForAll(user1, operator2), "Both operators should be in the set");
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator1)
+        && nodeLicense.isDelegationApprovedForAll(user1, operator2),
+      "Both operators should be in the set"
+    );
 
     // user1 revokes operator1
     vm.prank(user1);
@@ -398,8 +420,13 @@ contract NodeLicenseTest is Base {
     emit NodeLicense.DelegateApprovalForAll(user1, operator1, false);
     nodeLicense.setDelegationApprovalForAll(operator1, false);
 
-    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator1), "operator1 should NOT be approved after revocation");
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should still be approved");
+    assertFalse(
+      nodeLicense.isDelegationApprovedForAll(user1, operator1),
+      "operator1 should NOT be approved after revocation"
+    );
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should still be approved"
+    );
     address[] memory operatorsAfterOp1Revoke = nodeLicense.getDelegateOperatorsForOwner(user1);
     assertEq(operatorsAfterOp1Revoke.length, 1, "Should have 1 operator after revoking operator1");
     assertEq(operatorsAfterOp1Revoke[0], operator2, "The remaining operator should be operator2");
@@ -407,27 +434,40 @@ contract NodeLicenseTest is Base {
     // user1 approves operator3 (to test order with operator2 still present)
     vm.prank(user1);
     nodeLicense.setDelegationApprovalForAll(operator3, true);
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should be approved");
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should still be approved");
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should be approved"
+    );
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should still be approved"
+    );
     assertEq(nodeLicense.getDelegateOperatorsForOwner(user1).length, 2, "Should have 2 operators");
 
     // user1 revokes operator2
     vm.prank(user1);
     nodeLicense.setDelegationApprovalForAll(operator2, false);
-    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should be revoked");
-    assertTrue(nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should still be approved");
+    assertFalse(
+      nodeLicense.isDelegationApprovedForAll(user1, operator2), "operator2 should be revoked"
+    );
+    assertTrue(
+      nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should still be approved"
+    );
     address[] memory operatorsAfterOp2Revoke = nodeLicense.getDelegateOperatorsForOwner(user1);
     assertEq(operatorsAfterOp2Revoke.length, 1, "Should have 1 operator after revoking operator2");
     assertEq(operatorsAfterOp2Revoke[0], operator3, "The remaining operator should be operator3");
-    
+
     // Revoke last operator (operator3)
     vm.prank(user1);
     nodeLicense.setDelegationApprovalForAll(operator3, false);
-    assertFalse(nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should be revoked");
+    assertFalse(
+      nodeLicense.isDelegationApprovedForAll(user1, operator3), "operator3 should be revoked"
+    );
     assertEq(nodeLicense.getDelegateOperatorsForOwner(user1).length, 0, "Should have 0 operators");
 
     // Check approvals for a different owner (no interference)
-    assertFalse(nodeLicense.isDelegationApprovedForAll(operator1, operator2), "operator1 should not have approved operator2 for itself");
+    assertFalse(
+      nodeLicense.isDelegationApprovedForAll(operator1, operator2),
+      "operator1 should not have approved operator2 for itself"
+    );
   }
 
   function test_SetDelegationApprovalForAll_RevertOnZeroAddressOperator() public {
@@ -446,7 +486,11 @@ contract NodeLicenseTest is Base {
     // Initially, lock the token with the mockStakingManager
     bytes32 lockId = keccak256("test-lock-for-zero-address-test");
     // Ensure mockStakingManager is the current one from setUp
-    assertEq(nodeLicense.getNFTStakingManager(), address(mockStakingManager), "Initial staking manager mismatch");
+    assertEq(
+      nodeLicense.getNFTStakingManager(),
+      address(mockStakingManager),
+      "Initial staking manager mismatch"
+    );
     vm.prank(address(mockStakingManager)); // Staking manager itself locks the token
     mockStakingManager.setTokenLocked(tokenId, lockId);
 


### PR DESCRIPTION
Add mappings from owner to validations and owner to delegations.

These are created when `initiate` is called and removed when the last rewards are distributed, or when complete validator removal is called and there are no rewards left