### PR TITLE
Update license count when delegator has completed removal

### DIFF
--- a/contracts/NFTStakingManager.sol
+++ b/contracts/NFTStakingManager.sol
@@ -715,6 +715,9 @@ contract NFTStakingManager is
     delegation.status = DelegatorStatus.Removed;
 
     _unlockTokens(delegationID, delegation.tokenIDs);
+
+    $.validations[validationID].licenseCount -= uint32(delegation.tokenIDs.length);
+
     emit CompletedDelegatorRemoval(validationID, delegationID, nonce);
     return delegationID;
   }
@@ -793,10 +796,6 @@ contract NFTStakingManager is
       ) {
         delegation.uptimeCheck.add(previousEpoch);
         epochInfo.totalStakedLicenses += uint32(delegation.tokenIDs.length);
-      }
-
-      if (delegation.status != DelegatorStatus.Active) {
-        validation.licenseCount -= uint32(delegation.tokenIDs.length);
       }
     }
   }

--- a/tests/NFTStakingManager/NFTStakingManagerDelegatorRemoval.t.sol
+++ b/tests/NFTStakingManager/NFTStakingManagerDelegatorRemoval.t.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.25;
 import {
   DelegationInfoView,
   DelegatorStatus,
-  NFTStakingManager
+  NFTStakingManager,
+  ValidationInfoView
 } from "../../contracts/NFTStakingManager.sol";
 import { NFTStakingManagerBase } from "../utils/NFTStakingManagerBase.sol";
 import { console2 } from "forge-std-1.9.6/src/console2.sol";
@@ -218,6 +219,9 @@ contract NFTStakingManagerDelegatorRemovalTest is NFTStakingManagerBase {
     (bytes32 validationID,) = _createValidator();
     (bytes32 delegationID, address delegator) = _createDelegation(validationID, 1);
 
+    ValidationInfoView memory validation = nftStakingManager.getValidationInfoView(validationID);
+    assertEq(validation.licenseCount, 1);
+
     // Initiate removal
     bytes32[] memory delegationIDs = new bytes32[](1);
     delegationIDs[0] = delegationID;
@@ -233,6 +237,10 @@ contract NFTStakingManagerDelegatorRemovalTest is NFTStakingManagerBase {
     for (uint256 i = 0; i < delegation.tokenIDs.length; i++) {
       assertEq(nftStakingManager.getTokenLockedBy(delegation.tokenIDs[i]), bytes32(0));
     }
+
+    // Verify the license count is updated
+    validation = nftStakingManager.getValidationInfoView(validationID);
+    assertEq(validation.licenseCount, 0, "License count should be 0 after removal");
   }
 
   function test_completeDelegatorRemoval_multipleDelegations() public {


### PR DESCRIPTION
We were previously updating license count when a delegator is no longer active and we process a proof, but instead we can update the count when the delegator has been removed. 

This way the validator still has control over removing a delegator, and the delegator can still claim rewards