### PR TITLE
Unstick delegators

### DIFF
--- a/contracts/NFTStakingManager.sol
+++ b/contracts/NFTStakingManager.sol
@@ -641,23 +641,31 @@ contract NFTStakingManager is
         revert UnauthorizedOwner();
       }
 
-      if (delegation.status != DelegatorStatus.Active) {
+      if (
+        delegation.status != DelegatorStatus.Active
+          && delegation.status != DelegatorStatus.PendingAdded
+      ) {
         revert InvalidDelegatorStatus(delegation.status);
       }
 
-      uint64 newWeight = validator.weight - $.nodeLicenseWeight * uint64(delegation.tokenIDs.length);
+      // if the validator is not active, the weight update call will revert
+      if (validator.status == ValidatorStatus.Active) {
+        uint64 newWeight =
+          validator.weight - $.nodeLicenseWeight * uint64(delegation.tokenIDs.length);
 
-      (uint64 nonce,) =
-        $.validatorManager.initiateValidatorWeightUpdate(delegation.validationID, newWeight);
+        (uint64 nonce,) =
+          $.validatorManager.initiateValidatorWeightUpdate(delegation.validationID, newWeight);
 
-      uint32 epoch = getEpochByTimestamp(block.timestamp);
-      if ((getEpochEndTime(epoch - 1) + ($.epochDuration / 2)) > block.timestamp) {
-        delegation.endEpoch = epoch - 1;
-      } else {
-        delegation.endEpoch = epoch;
+        uint32 epoch = getEpochByTimestamp(block.timestamp);
+        if ((getEpochEndTime(epoch - 1) + ($.epochDuration / 2)) > block.timestamp) {
+          delegation.endEpoch = epoch - 1;
+        } else {
+          delegation.endEpoch = epoch;
+        }
+
+        delegation.endingNonce = nonce;
       }
 
-      delegation.endingNonce = nonce;
       delegation.status = DelegatorStatus.PendingRemoved;
 
       emit InitiatedDelegatorRemoval(

--- a/contracts/NFTStakingManager.sol
+++ b/contracts/NFTStakingManager.sol
@@ -422,7 +422,10 @@ contract NFTStakingManager is
     for (uint256 i = 0; i < validation.delegationIDs.length(); i++) {
       bytes32 delegationID = validation.delegationIDs.at(i);
       DelegationInfo storage delegation = $.delegations[delegationID];
-      if (delegation.status == DelegatorStatus.Active) {
+      if (
+        delegation.status == DelegatorStatus.Active
+          || delegation.status == DelegatorStatus.PendingAdded
+      ) {
         revert ValidatorHasActiveDelegations();
       }
     }
@@ -641,10 +644,7 @@ contract NFTStakingManager is
         revert UnauthorizedOwner();
       }
 
-      if (
-        delegation.status != DelegatorStatus.Active
-          && delegation.status != DelegatorStatus.PendingAdded
-      ) {
+      if (delegation.status != DelegatorStatus.Active) {
         revert InvalidDelegatorStatus(delegation.status);
       }
 

--- a/tests/NFTStakingManager/NFTStakingManagerValidatorRemoval.t.sol
+++ b/tests/NFTStakingManager/NFTStakingManagerValidatorRemoval.t.sol
@@ -111,4 +111,25 @@ contract NFTStakingManagerValidatorRemovalTest is NFTStakingManagerBase {
     Validator memory v = validatorManager.getValidator(validationID);
     assertEq(uint8(v.status), uint8(ValidatorStatus.PendingRemoved));
   }
+
+  function test_validatorRemoval_pendingAddedDelegation() public {
+    address delegator = getActor("Delegator");
+    (bytes32 validationID, address validator) = _createValidator();
+
+    uint256[] memory tokenIDs = new uint256[](1);
+    tokenIDs[0] = nft.mint(delegator);
+
+    vm.prank(delegator);
+    bytes32 delegationID = nftStakingManager.initiateDelegatorRegistration(validationID, tokenIDs);
+
+    vm.prank(validator);
+    nftStakingManager.initiateValidatorRemoval(validationID);
+
+    bytes32[] memory delegationIDs = new bytes32[](1);
+    delegationIDs[0] = delegationID;
+    vm.prank(delegator);
+    nftStakingManager.initiateDelegatorRemoval(delegationIDs);
+
+    nftStakingManager.completeDelegatorRemoval(delegationID, 0);
+  }
 }

--- a/tests/NFTStakingManager/NFTStakingManagerValidatorRemoval.t.sol
+++ b/tests/NFTStakingManager/NFTStakingManagerValidatorRemoval.t.sol
@@ -122,14 +122,9 @@ contract NFTStakingManagerValidatorRemovalTest is NFTStakingManagerBase {
     vm.prank(delegator);
     bytes32 delegationID = nftStakingManager.initiateDelegatorRegistration(validationID, tokenIDs);
 
-    vm.prank(validator);
+    vm.startPrank(validator);
+    vm.expectRevert(NFTStakingManager.ValidatorHasActiveDelegations.selector);
     nftStakingManager.initiateValidatorRemoval(validationID);
-
-    bytes32[] memory delegationIDs = new bytes32[](1);
-    delegationIDs[0] = delegationID;
-    vm.prank(delegator);
-    nftStakingManager.initiateDelegatorRemoval(delegationIDs);
-
-    nftStakingManager.completeDelegatorRemoval(delegationID, 0);
+    vm.stopPrank();
   }
 }


### PR DESCRIPTION
Allow delegators to be removed if they are in the `PendingAdded` state. 

An edge case I found here is that if we call `ValidatorManager::initiateValidatorWeightUpdate` and the validator is not active, the call reverts. So when we `initiateDelegatorRemoval` first check the validator status, and if it's not active don't attempt to update the weight. 

This will still work for `completeDelegatorRemoval` because we check if the ending nonce is less than the last received nonce from the validator. 